### PR TITLE
[홈 진입] 기본 응답 컨트롤러 구현

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/controller/HomeController.java
+++ b/src/main/java/com/team03/ticketmon/_global/controller/HomeController.java
@@ -1,0 +1,13 @@
+package com.team03.ticketmon._global.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public String index() {
+        return "서비스가 정상적으로 실행 중입니다!";
+    }
+}


### PR DESCRIPTION
### 작업 내용

- [x] 루트 경로(`/`) 요청 시 텍스트 응답을 반환하는 HomeController 생성
- [x] 예외 처리기에서 반환되던 500 오류 방지

### 주요 변경사항

- **새로 추가된 파일**:
  - `HomeController.java`
    (`com.team03.ticketmon._global.controller` 패키지 내)
- **수정된 파일**: 없음
- **삭제된 파일**: 없음

### 관련 이슈

- Related to #서비스 초기 진입 500 오류

---

### 5. 배포 확인사항

- [x] 로컬 환경에서 정상 동작 확인
- [ ] Docker 컨테이너 빌드 성공
- [ ] 환경변수 설정 확인
- [ ] DB 마이그레이션 필요 여부 체크


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint at the root path (/) that confirms the service is running with a status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->