### PR TITLE
[예매] 예매 API 예외 처리 고도화 및 Swagger 문서 적용

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/exception/ErrorCode.java
+++ b/src/main/java/com/team03/ticketmon/_global/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     // Auth & User (인증 및 사용자 관련)
     LOGIN_FAILED(401, "A001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN(401, "A002", "인증 토큰이 유효하지 않습니다."),
-    ACCESS_DENIED(403, "A003", "해당 리소스에 접근할 권한이 없습니다."),
+    ACCESS_DENIED(403, "A003", "해당 예매를 취소할 권한이 없습니다."),
     EMAIL_DUPLICATION(409, "A004", "이미 가입된 이메일입니다."),
     SELLER_APPLY_ONCE(400, "A005", "판매자 권한 신청은 한 번만 가능합니다."),
     AUTHENTICATION_REQUIRED(401, "A006", "인증이 필요한 요청입니다. 로그인이 필요합니다."), // <--- 추가됨
@@ -73,6 +73,7 @@ public enum ErrorCode {
     INVALID_SEAT_SELECTION(400, "B007", "선택한 좌석 중 일부를 찾을 수 없습니다."),
     BOOKING_NOT_FOUND(404, "B008", "요청한 예매 정보를 찾을 수 없습니다."),
     ALREADY_CANCELED_BOOKING(409, "B009", "이미 취소 처리된 예매입니다."),
+    ALREADY_COMPLETE_BOOKING(409, "B010", "이미 관람(사용)이 완료된 예매는 취소할 수 없습니다."),
 
     // Review & Expectation (후기 및 기대평) - 새롭게 추가된 도메인
     REVIEW_ALREADY_EXISTS(409, "R001", "이미 후기를 작성했습니다."), // 추가: 중복 후기 방지

--- a/src/main/java/com/team03/ticketmon/booking/service/BookingService.java
+++ b/src/main/java/com/team03/ticketmon/booking/service/BookingService.java
@@ -138,6 +138,9 @@ public class BookingService {
         if (booking.getStatus() == BookingStatus.CANCELED) {
             throw new BusinessException(ErrorCode.ALREADY_CANCELED_BOOKING);
         }
+        if (booking.getStatus() == BookingStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.ALREADY_COMPLETE_BOOKING);
+        }
 
         // 4. 히스토리 테이블로 이관하는 로직 호출
         archiveBookingAndTickets(booking);


### PR DESCRIPTION
#### **1. 작업 개요**

본 PR은 예매(Booking) API의 **안정성과 사용성**을 한 단계 높이는 것을 목표로 합니다.

첫째, 예매 취소 로직의 예외 처리를 더 견고하고 웹 표준에 맞게 개선합니다. 둘째, **Swagger(OpenAPI)를 도입**하여 API 명세를 코드 기반으로 자동화함으로써, 프론트엔드를 포함한 모든 팀원과의 협업 효율을 극대화하고자 합니다.

#### **2. 주요 작업 내용**

  * **예매 취소 불가 조건 추가**: 이미 '관람 완료'된 예매는 취소할 수 없도록 비즈니스 규칙을 추가하고, 관련 `ErrorCode`를 정의했습니다.
  * **Swagger API 문서화**: `BookingController` 전체에 `@Tag`, `@Operation`, `@ApiResponses` 등의 애너테이션을 적용하여, API의 기능, 요청/응답 형식, 모든 예외 케이스를 명세화했습니다.

#### **3. 주요 변경사항**

✨ **수정된 파일:**

  * `_global/exception/ErrorCode.java`: `ACCESS_DENIED` 수정 및 `ALREADY_COMPLETE_BOOKING` 추가
  * `booking/service/BookingService.java`: `cancelBooking` 메서드에 '완료된 예매' 취소 방지 로직 추가
  * `booking/controller/BookingController.java`: `ApiResponses` 수정 및 클래스 전체에 Swagger 애너테이션 적용

#### **4. 추가 정보 (리뷰어를 위한 가이드)**

##### **1. 시맨틱한 에러 처리로의 개선**

이번 변경을 통해 API는 이제 실패 원인을 더 명확하게 알려줍니다.

  * **`401 Unauthorized`**: "로그인이 필요합니다." (인증 문제)
  * **`403 Forbidden`**: "권한이 없습니다." (인가 문제)
  * **`409 Conflict`**: "이미 처리된 요청입니다." (상태 문제)

이처럼 명확하게 분리된 에러 코드는 클라이언트 측에서 상황에 맞는 후속 처리를 구현하는 데 큰 도움이 됩니다.

##### **2. 코드 기반 API 문서화의 도입**

Swagger 도입으로 얻는 가장 큰 이점은 **API 명세와 실제 코드가 항상 일치**한다는 것입니다. `cancelBooking` API의 `@ApiResponses`를 보면, 이번에 개선된 `403`, `409` 예외 상황이 그대로 문서에 반영된 것을 확인할 수 있습니다.

이는 별도의 API 문서를 수동으로 관리할 필요 없이, 모든 팀원이 항상 최신화된 API 계약을 기반으로 협업할 수 있는 환경을 제공합니다. Swagger UI를 통한 API 직접 테스트 기능은 개발 및 QA 생산성을 크게 향상시킬 것입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증 필요, 사용자 미존재, 필수 요청 파라미터 누락, 이미 완료된 예매 취소 불가, 후기 중복 작성 등 세분화된 오류 메시지가 추가되었습니다.

- **버그 수정**
    - 이미 완료(사용)된 예매는 더 이상 취소할 수 없도록 예매 취소 시 검증이 강화되었습니다.

- **문서화**
    - 예매 생성 및 취소 API에 대한 Swagger 문서가 추가되어 응답 코드 및 설명이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->