### PR TITLE
[FIX] 선점 시 seatInfo 덮어쓰기 문제 해결 및 캐시 포맷 일관화

### DIFF
--- a/src/main/java/com/team03/ticketmon/seat/controller/SeatReservationController.java
+++ b/src/main/java/com/team03/ticketmon/seat/controller/SeatReservationController.java
@@ -18,10 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -108,12 +105,10 @@ public class SeatReservationController {
                 }
             }
 
-            // 2. 좌석 정보 생성 (실제로는 DB에서 조회)
-            String seatInfo = generateSeatInfo(seatId.intValue());
 
-            // 3. 좌석 선점 처리 (서비스 레이어의 원자적 처리 활용)
+            // 2. 좌석 선점 처리 (서비스 레이어의 원자적 처리 활용)
             SeatStatus reservedSeat = seatStatusService.reserveSeat(
-                    concertId, seatId, user.getUserId(), seatInfo);
+                    concertId, seatId, user.getUserId());
 
             SeatStatusResponse response = SeatStatusResponse.from(reservedSeat);
 
@@ -150,9 +145,8 @@ public class SeatReservationController {
         }
     }
 
-    // ✅ 핵심 수정: @PostMapping → @DeleteMapping으로 변경
     @Operation(summary = "좌석 선점 해제", description = "임시 선점된 좌석을 해제합니다 (권한 검증 포함)")
-    @DeleteMapping("/concerts/{concertId}/seats/{seatId}/release")
+    @PostMapping("/concerts/{concertId}/seats/{seatId}/release")
     public ResponseEntity<SuccessResponse<String>> releaseSeat(
             @Parameter(description = "콘서트 ID", example = "1")
             @PathVariable Long concertId,

--- a/src/main/java/com/team03/ticketmon/seat/service/SeatCacheInitService.java
+++ b/src/main/java/com/team03/ticketmon/seat/service/SeatCacheInitService.java
@@ -159,9 +159,10 @@ public class SeatCacheInitService {
         }
 
         String section = seat.getSection() != null ? seat.getSection() : "?";
-        Integer seatNumber = seat.getSeatNumber() != null ? seat.getSeatNumber() : 0;
+        String seatRow = seat.getSeatRow() != null ? seat.getSeatRow() : "?";
+        int seatNumber = seat.getSeatNumber() != null ? seat.getSeatNumber() : 0;
 
-        return section + "-" + seatNumber;
+        return section + "-" + seatRow + "-" + seatNumber;
     }
 
     /**


### PR DESCRIPTION
# 🎫 [예약] seatInfo 덮어쓰기 버그 수정 및 캐시 포맷 개선

## 📋 변경사항

1. **SeatCacheInitService**

   * `generateSeatInfoFromDB`에서 `section-seatRow-seatNumber` 형태로 포맷 수정
   * 배포 후 Redis 캐시 재초기화를 위해 주석 가이드 추가

2. **SeatReservationController**

   * `generateSeatInfo(...)` 호출 제거
   * `seatStatusService.reserveSeat(concertId, seatId, userId)` 시그니처에 맞춰 호출 인수 정리

3. **SeatStatusService**

   * `reserveSeat` 메서드 시그니처에서 `seatInfo` 파라미터 제거
   * 내부 로직에서 `old.getSeatInfo()`를 가져와 빌더에 그대로 주입

4. **문서(주석)**

   * Redis 캐시를 `clear()` 후 `initializeSeatCacheFromDB` 호출하는 방법을 코드 주석으로 안내

## ✅ 테스트 시나리오

1. **캐시 초기화**

   ```bash
   # Redis CLI
   DEL seat:status:{concertId}
   ```

   * 서버 재시작 또는 수동 호출로 `initializeSeatCacheFromDB(concertId)` 실행
   * 각 `seatInfo` 값이 `A-1-1`, `A-1-2`… 형태로 정상 저장되는지 확인

2. **좌석 선점 흐름**

   * `POST /api/seats/concerts/{concertId}/seats/{seatId}/reserve` 호출
   * 반환된 `SeatStatusResponse.seatInfo`가 캐시 초기값과 일치하는지 검증
   * Redis 내부 자료구조에서 `seatInfo`가 변경 없이 유지되는지 확인

3. **프론트 정상 렌더링**

   * 웹 UI에서 좌석 클릭 후에도 “행-번호” 파싱 오류 없어야 함
   * 그리드에서 좌석이 사라지거나 위치가 바뀌는 문제 해결 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 좌석 해제 요청 시 HTTP 메서드가 DELETE에서 POST로 변경되었습니다.

* **리팩터링**
  * 좌석 예약 시 내부적으로 좌석 정보 처리 방식이 개선되어, 기존 파라미터 전달 없이 캐시된 좌석 정보를 활용하도록 변경되었습니다.
  * 좌석 정보 생성 시 좌석 구역, 행, 번호가 모두 포함되도록 문자열 포맷이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->