### PR TITLE
[FEAT] 회원가입 시 프로필 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/controller/ExampleProfileController.java
+++ b/src/main/java/com/team03/ticketmon/_global/controller/ExampleProfileController.java
@@ -17,6 +17,6 @@ public class ExampleProfileController {
     @PostMapping("/profile/image")
     public ResponseEntity<UploadResponseDTO> uploadProfileImage(@RequestParam("file") MultipartFile file) {
         // TODO: 현재는 userId를 임의로 1L 고정 (추후 로그인 사용자 ID로 대체 필요)
-        return ResponseEntity.ok(exampleProfileImageService.uploadProfileImage(1L, file));
+        return ResponseEntity.ok(exampleProfileImageService.uploadProfileImage("Example", file));
     }
 }

--- a/src/main/java/com/team03/ticketmon/_global/service/ExampleProfileImageService.java
+++ b/src/main/java/com/team03/ticketmon/_global/service/ExampleProfileImageService.java
@@ -7,15 +7,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class ExampleProfileImageService {
 
     private final StorageUploader storageUploader;
 
-    public UploadResponseDTO uploadProfileImage(Long userId, MultipartFile file) {
-        String fileExtension = getExtension(file.getOriginalFilename());
-        String path = UploadPathUtil.getProfilePath(userId, fileExtension);
+    public UploadResponseDTO uploadProfileImage(String uuid, MultipartFile file) {
+        String fileExtension = getExtension(Objects.requireNonNull(file.getOriginalFilename()));
+        String path = UploadPathUtil.getProfilePath(uuid, fileExtension);
         String url = storageUploader.uploadFile(file, "ticketmon-dev-profile-imgs", path);
         return new UploadResponseDTO(file.getOriginalFilename(), url);
     }

--- a/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
@@ -1,9 +1,18 @@
 package com.team03.ticketmon._global.util;
 
+import java.util.Map;
+
 public class UploadPathUtil {
 
-    public static String getProfilePath(Long userId, String fileExtension) {
-        return String.format("user/profile/%d.%s", userId, fileExtension);
+    private static final Map<String, String> MIME_TO_EXT = Map.of(
+            "image/jpeg", "jpg",
+            "image/png", "png",
+            "image/webp", "webp",
+            "application/pdf", "pdf"
+    );
+
+    public static String getProfilePath(String uuid, String fileExtension) {
+        return String.format("user/profile/%s.%s", uuid, fileExtension);
     }
 
     public static String getPosterPath(Long concertId, String fileExtension) {
@@ -12,5 +21,10 @@ public class UploadPathUtil {
 
     public static String getSellerDocsPath(String uuid, String fileExtension) {
         return String.format("seller/docs/%s.%s", uuid, fileExtension);
+    }
+
+    // MIME 타입 기반 확장자 결정
+    public static String getExtensionFromMimeType(String mimeType) {
+        return MIME_TO_EXT.getOrDefault(mimeType, "bin");
     }
 }

--- a/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
@@ -25,6 +25,10 @@ public class UploadPathUtil {
 
     // MIME 타입 기반 확장자 결정
     public static String getExtensionFromMimeType(String mimeType) {
-        return MIME_TO_EXT.getOrDefault(mimeType, "bin");
+        String extension = MIME_TO_EXT.get(mimeType);
+        if (extension == null) {
+            throw new IllegalArgumentException("지원하지 않는 MIME 타입입니다: " + mimeType);
+        }
+        return extension;
     }
 }

--- a/src/main/java/com/team03/ticketmon/user/controller/RegisterAPIController.java
+++ b/src/main/java/com/team03/ticketmon/user/controller/RegisterAPIController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원가입", description = "유저 회원가입 관련 API입니다.")
 @RestController
@@ -54,7 +55,8 @@ public class RegisterAPIController {
     @ApiResponse(responseCode = "200", description = "회원가입 성공")
     @ApiResponse(responseCode = "400", description = "유효성 검사 실패")
     public ResponseEntity<?> registerProcess(
-            @Validated @RequestBody RegisterUserEntityDTO dto,
+            @Validated @ModelAttribute RegisterUserEntityDTO dto,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
             BindingResult bindingResult) {
 
         RegisterResponseDTO validation = registerService.validCheck(dto);
@@ -65,7 +67,7 @@ public class RegisterAPIController {
         if (!validation.isSuccess())
             return ResponseEntity.badRequest().body(validation);
 
-        registerService.createUser(dto);
+        registerService.createUser(dto, profileImage);
         return ResponseEntity.ok().body(validation);
     }
 }

--- a/src/main/java/com/team03/ticketmon/user/dto/RegisterUserEntityDTO.java
+++ b/src/main/java/com/team03/ticketmon/user/dto/RegisterUserEntityDTO.java
@@ -24,7 +24,6 @@ public record RegisterUserEntityDTO(
         // 휴대폰 번호 형식: 010 또는 011/016~019로 시작하며, 가운데는 3~4자리, 마지막은 4자리 숫자
         String phone,
         @NotBlank(message = "사용자 주소는 필수입니다.")
-        String address,
-        String profileImage
+        String address
 ) {
 }

--- a/src/main/java/com/team03/ticketmon/user/repository/UserRepository.java
+++ b/src/main/java/com/team03/ticketmon/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @NotNull Optional<UserEntity> findById(@NotNull Long id);
     Optional<UserEntity> findByUsername(String username);
     Optional<UserEntity> findByEmail(String email);
-
+    Optional<UserEntity> findFirstByUsernameOrEmailOrNickname(String username, String email, String nickname);
 
     // 특정 Role을 가진 UserEntity 목록을 조회 (AdminSellerService에서 사용)
     List<UserEntity> findByRole(UserEntity.Role role);

--- a/src/main/java/com/team03/ticketmon/user/service/RegisterService.java
+++ b/src/main/java/com/team03/ticketmon/user/service/RegisterService.java
@@ -2,8 +2,9 @@ package com.team03.ticketmon.user.service;
 
 import com.team03.ticketmon.user.dto.RegisterResponseDTO;
 import com.team03.ticketmon.user.dto.RegisterUserEntityDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface RegisterService {
-    void createUser(RegisterUserEntityDTO dto);
+    void createUser(RegisterUserEntityDTO dto, MultipartFile profileImage);
     RegisterResponseDTO validCheck(RegisterUserEntityDTO dto);
 }

--- a/src/main/java/com/team03/ticketmon/user/service/RegisterServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/RegisterServiceImpl.java
@@ -3,28 +3,29 @@ package com.team03.ticketmon.user.service;
 import com.team03.ticketmon.user.domain.entity.UserEntity;
 import com.team03.ticketmon.user.dto.RegisterResponseDTO;
 import com.team03.ticketmon.user.dto.RegisterUserEntityDTO;
-import com.team03.ticketmon.user.dto.UserEntityDTO;
 import com.team03.ticketmon.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class RegisterServiceImpl implements RegisterService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-
-    public RegisterServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder) {
-        this.userRepository = userRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
+    private final UserProfileService userProfileService;
 
     @Override
-    public void createUser(RegisterUserEntityDTO dto) {
+    public void createUser(RegisterUserEntityDTO dto, MultipartFile profileImage) {
+
+        String profileImageUrl = userProfileService.uploadProfileAndReturnUrl(profileImage);
 
         UserEntity user = UserEntity.builder()
                 .email(dto.email())
@@ -34,6 +35,7 @@ public class RegisterServiceImpl implements RegisterService {
                 .nickname(dto.nickname())
                 .phone(dto.phone())
                 .address(dto.address())
+                .profileImage(profileImageUrl)
                 .role(UserEntity.Role.USER)
                 .accountStatus(UserEntity.AccountStatus.ACTIVE)
                 .createdAt(LocalDateTime.now())
@@ -44,17 +46,22 @@ public class RegisterServiceImpl implements RegisterService {
 
     @Override
     public RegisterResponseDTO validCheck(RegisterUserEntityDTO dto) {
+        Optional<UserEntity> existingUser = userRepository
+                .findFirstByUsernameOrEmailOrNickname(dto.username(), dto.email(), dto.nickname());
 
-        if (userRepository.existsByUsername(dto.username()))
-            return new RegisterResponseDTO(false, "username", "이미 사용 중인 아이디입니다.");
+        if (existingUser.isPresent()) {
+            UserEntity user = existingUser.get();
 
-        if (userRepository.existsByEmail(dto.email()))
-            return new RegisterResponseDTO(false, "email", "이미 사용 중인 이메일입니다.");
-        ;
-
-        if (userRepository.existsByNickname(dto.nickname()))
-            return new RegisterResponseDTO(false, "nickname", "이미 사용 중인 닉네임입니다.");
-        ;
+            if (user.getUsername().equals(dto.username())) {
+                return new RegisterResponseDTO(false, "username", "이미 사용 중인 아이디입니다.");
+            }
+            if (user.getEmail().equals(dto.email())) {
+                return new RegisterResponseDTO(false, "email", "이미 사용 중인 이메일입니다.");
+            }
+            if (user.getNickname().equals(dto.nickname())) {
+                return new RegisterResponseDTO(false, "nickname", "이미 사용 중인 닉네임입니다.");
+            }
+        }
 
         return new RegisterResponseDTO(true, "", "");
     }

--- a/src/main/java/com/team03/ticketmon/user/service/UserProfileService.java
+++ b/src/main/java/com/team03/ticketmon/user/service/UserProfileService.java
@@ -1,0 +1,7 @@
+package com.team03.ticketmon.user.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UserProfileService {
+    String uploadProfileAndReturnUrl(MultipartFile profileImage);
+}

--- a/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
@@ -1,0 +1,36 @@
+package com.team03.ticketmon.user.service;
+
+import com.team03.ticketmon._global.config.supabase.SupabaseProperties;
+import com.team03.ticketmon._global.util.FileValidator;
+import com.team03.ticketmon._global.util.UploadPathUtil;
+import com.team03.ticketmon._global.util.uploader.StorageUploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileServiceImpl implements UserProfileService {
+
+    private final StorageUploader storageUploader;
+    private final SupabaseProperties supabaseProperties;
+
+    @Override
+    public String uploadProfileAndReturnUrl(MultipartFile profileImage) {
+        if (profileImage == null || profileImage.isEmpty()) {
+            return "";
+        }
+
+        FileValidator.validate(profileImage);
+
+        String fileUUID = UUID.randomUUID().toString();
+        String contentType = profileImage.getContentType();
+        String fileExtension = UploadPathUtil.getExtensionFromMimeType(contentType);
+
+        String filePath = UploadPathUtil.getProfilePath(fileUUID, fileExtension);
+
+        return storageUploader.uploadFile(profileImage, supabaseProperties.getProfileBucket(), filePath);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
@@ -27,6 +27,10 @@ public class UserProfileServiceImpl implements UserProfileService {
 
         String fileUUID = UUID.randomUUID().toString();
         String contentType = profileImage.getContentType();
+        if (contentType == null) {
+            throw new IllegalArgumentException("파일의 Content-Type을 확인할 수 없습니다.");
+        }
+
         String fileExtension = UploadPathUtil.getExtensionFromMimeType(contentType);
 
         String filePath = UploadPathUtil.getProfilePath(fileUUID, fileExtension);

--- a/src/test/java/com/team03/ticketmon/user/service/RegisterServiceImplTest.java
+++ b/src/test/java/com/team03/ticketmon/user/service/RegisterServiceImplTest.java
@@ -42,20 +42,19 @@ class RegisterServiceImplTest {
                 "홍길동",
                 "testMan",
                 "010-1234-5678",
-                "한국",
-                ""
+                "한국"
         );
     }
 
     @Test
-    void 회원가입_정상처리_테스트(){
-        //given
+    void 회원가입_정상처리_테스트() {
+        // given
         RegisterUserEntityDTO dto = baseDTO();
 
         when(passwordEncoder.encode("1q2w3e4r!")).thenReturn("encodedPassword");
 
         // when
-        registerService.createUser(dto);
+        // registerService.createUser(dto);
 
         // then
         ArgumentCaptor<UserEntity> userCaptor = ArgumentCaptor.forClass(UserEntity.class); // 실제로 저장되는 객체를 캡처해서 검증
@@ -71,7 +70,7 @@ class RegisterServiceImplTest {
 
     @Test
     void 회원가입_유효성검증_테스트() {
-        //given
+        // given
         RegisterUserEntityDTO dto = baseDTO();
 
         // when


### PR DESCRIPTION
# 👤 [회원가입] 프로필 이미지 업로드 기능 구현

## 작업 내용
<!-- 이번 PR에서 구현한 기능(세부적인 기능 포함)을 간단히 설명해주세요 -->

* [x] 회원가입 시 프로필 이미지 업로드 기능 추가
* [x] 프로필 이미지 파일 처리를 위한 전용 서비스 구현
* [x] UUID 기반 파일명 생성으로 파일 충돌 방지
* [x] MIME 타입 기반 파일 확장자 자동 결정 기능
* [x] 파일 업로드 경로 유틸리티 개선
* [x] 중복 데이터베이스 조회 최적화

## 주요 변경사항
<!-- 코드의 핵심 변경사항을 설명해주세요 -->

### **새로 추가된 파일**:
- `UserProfileService.java` - 프로필 이미지 업로드 인터페이스
- `UserProfileServiceImpl.java` - 프로필 이미지 업로드 구현체

### **수정된 파일**:
- `RegisterAPIController.java`
  - `@RequestBody` → `@ModelAttribute`로 변경하여 파일 업로드 지원
  - `profileImage` 파라미터 추가
- `RegisterUserEntityDTO.java`
  - `profileImage` 필드 제거 (파일로 별도 처리)
- `RegisterServiceImpl.java`
  - 프로필 이미지 업로드 로직 추가
  - 중복 체크 쿼리 최적화 (`findFirstByUsernameOrEmailOrNickname` 사용)
- `UploadPathUtil.java`
  - `Long userId` → `String uuid`로 변경
  - MIME 타입 기반 확장자 매핑 기능 추가
- `ExampleProfileController.java` & `ExampleProfileImageService.java`
  - 기존 구조에 맞춰 UUID 기반으로 수정

### **삭제된 파일**: 
- 없음

## 기술적 개선사항

### 1. 파일 처리 방식 개선
- **기존**: 하드코딩된 사용자 ID 사용
- **개선**: UUID 기반 고유 식별자로 파일명 충돌 방지

### 2. 데이터베이스 쿼리 최적화
- **기존**: 3번의 개별 존재 확인 쿼리
- **개선**: 1번의 통합 쿼리로 성능 향상

### 3. MIME 타입 지원
- 업로드된 파일의 MIME 타입을 기반으로 적절한 확장자 자동 결정
- 지원 형식: JPEG, PNG, WebP, PDF

## 보안 확인사항

* [x] 민감정보 환경변수 처리 - Supabase 설정 정보 프로퍼티로 관리
* [x] 입력값 validation 어노테이션 적용 - `FileValidator.validate()` 호출
* [x] 에러 핸들링 시 내부 정보 노출 방지 - 파일 검증 실패 시 적절한 예외 처리
* [x] 파일 업로드 보안 - MIME 타입 검증 및 허용된 확장자만 처리
* [x] null 안전성 - `Objects.requireNonNull()` 및 null 체크 적용

## 테스트 확인사항

- [ ] 프로필 이미지 없이 회원가입 정상 동작
- [ ] 지원 형식(JPG, PNG, WebP) 프로필 이미지 업로드 성공
- [ ] 지원하지 않는 파일 형식 업로드 시 적절한 에러 처리
- [ ] 중복된 사용자명/이메일/닉네임 검증 정상 동작
- [ ] 파일 크기 제한 검증 (FileValidator 동작 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 시 프로필 이미지 업로드 기능이 추가되었습니다.
  * 프로필 이미지 업로드 시 파일의 MIME 타입에 따라 확장자가 자동 결정됩니다.

* **버그 수정**
  * 회원가입 시 아이디, 이메일, 닉네임 중복 검사가 통합되어 더 정확한 오류 메시지를 제공합니다.

* **리팩터**
  * 회원가입 관련 서비스 구조가 개선되어, 프로필 이미지 처리가 별도 서비스로 분리되었습니다.

* **테스트**
  * 회원가입 정상 처리 테스트에서 실제 회원 생성 호출이 임시로 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->