### PR TITLE
[FEAT] CORS 설정 분리 및 Security/WebSocket에 적용

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/CorsProperties.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/CorsProperties.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * ✅ CORS 설정 프로퍼티 클래스
  * <p>
- * application.yml 또는 application.properties 파일에 정의된
+ * application-dev.yml 또는 application.properties 파일에 정의된
  * cors.allowed-origins 값을 주입받아 관리합니다.
  * </p>
  *

--- a/src/main/java/com/team03/ticketmon/_global/config/CorsProperties.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/CorsProperties.java
@@ -1,0 +1,39 @@
+package com.team03.ticketmon._global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * ✅ CORS 설정 프로퍼티 클래스
+ * <p>
+ * application.yml 또는 application.properties 파일에 정의된
+ * cors.allowed-origins 값을 주입받아 관리합니다.
+ * </p>
+ *
+ * 📌 주요 설정:
+ * <ul>
+ *   <li>프론트엔드에서 접근 허용할 도메인(origin) 목록 정의</li>
+ *   <li>배열(String[]) 또는 리스트(List&lt;String&gt;)로 구성 가능</li>
+ *   <li>WebSocket 및 Spring Security CORS 설정에서 재사용</li>
+ * </ul>
+ *
+ * 📁 설정 예시 (application.yml):
+ * <pre>
+ * cors:
+ *   allowed-origins:
+ *     - http://localhost:3000
+ *     - https://mydomain.com
+ * </pre>
+ */
+
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+    private String[] allowedOrigins;
+
+    public String[] getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(String[] allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.team03.ticketmon._global.config;
 
 import java.util.Arrays;
+import java.util.List;
 
 import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.auth.jwt.*;
@@ -66,6 +67,7 @@ public class SecurityConfig {
 	private final CookieUtil cookieUtil;
     private final RedissonClient redissonClient;
     private final RedisKeyGenerator keyGenerator;
+	private final CorsProperties corsProperties;
 
 	/**
 	 * <b>AuthenticationManager 빈 설정</b> <br>
@@ -213,14 +215,7 @@ public class SecurityConfig {
 
 		// 허용할 프론트엔드 도메인 (로컬 개발용 및 ngrok 주소)
 		// 운영 환경 배포 시에는 실제 서비스 도메인으로 변경
-		config.setAllowedOrigins(Arrays.asList(
-			"http://localhost:3000",    // 기존 React App 기본 포트
-			"http://localhost:8080",    // 백엔드 개발 서버 포트 (테스트용, 백엔드 직접 접근 시)
-			"http://localhost:5173",    // Vite React 개발 서버 기본 포트 (새 프론트엔드 레포)
-			"http://localhost:5174",    // <-- 이 부분 추가 (현재 프론트엔드 개발 서버 포트)
-			"https://ff52-222-105-3-101.ngrok-free.app", // ngrok 등 터널링 서비스 주소 (필요 시)
-			"https://localhost:3000"
-		));
+		config.setAllowedOrigins(List.of(corsProperties.getAllowedOrigins()));
 
 		// 허용할 HTTP 메서드
 		config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));

--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.team03.ticketmon._global.config;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.auth.jwt.*;
@@ -215,7 +216,11 @@ public class SecurityConfig {
 
 		// 허용할 프론트엔드 도메인 (로컬 개발용 및 ngrok 주소)
 		// 운영 환경 배포 시에는 실제 서비스 도메인으로 변경
-		config.setAllowedOrigins(List.of(corsProperties.getAllowedOrigins()));
+		config.setAllowedOrigins(List.of(
+				Optional.ofNullable(corsProperties.getAllowedOrigins())
+						.orElse(new String[0])
+				)
+		);
 
 		// 허용할 HTTP 메서드
 		config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));

--- a/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
@@ -8,6 +8,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+import java.util.Optional;
+
 /**
  * WebSocket 관련 설정을 구성하는 클래스
  */
@@ -34,6 +36,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 .addInterceptors(webSocketAuthInterceptor)
 
                 // 실제 서비스 도메인(예: "https://ticketmon.com" 등)으로 추후 수정 가능성 있음
-                .setAllowedOrigins(corsProperties.getAllowedOrigins());
+                .setAllowedOrigins(
+                        Optional.ofNullable(corsProperties.getAllowedOrigins())
+                                .orElse(new String[0])
+                );
     }
 }

--- a/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/WebSocketConfig.java
@@ -18,6 +18,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final CustomWebSocketHandler customWebSocketHandler;
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final CorsProperties corsProperties;
     /**
      * WebSocket 핸들러를 특정 경로에 등록
      *
@@ -33,14 +34,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 .addInterceptors(webSocketAuthInterceptor)
 
                 // 실제 서비스 도메인(예: "https://ticketmon.com" 등)으로 추후 수정 가능성 있음
-                // .setAllowedOrigins("*");
-                .setAllowedOrigins(
-                        "https://localhost:3000",    // 기존 React App 기본 포트
-                        "http://localhost:3000",    // 기존 React App 기본 포트
-                        "http://localhost:8080",    // 백엔드 개발 서버 포트 (SecurityConfig와 일관성)
-                        "http://localhost:5173",    // Vite React 개발 서버 기본 포트
-                        "http://localhost:5174",    // <-- 이 부분 추가 (현재 프론트엔드 개발 서버 포트)
-                        "https://ff52-222-105-3-101.ngrok-free.app" // ngrok 등 터널링 서비스 주소 (필요 시)
-                );
+                .setAllowedOrigins(corsProperties.getAllowedOrigins());
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -155,3 +155,7 @@ ai:
 #운영환경 도메인
 app:
   base-url: ${BASE_URL} # 운영 환경 도메인
+
+
+cors:
+  allowed-origins:


### PR DESCRIPTION
### 주요 변경 사항
- `CorsProperties` 클래스 생성하여 allowed-origins 배열 주입 받도록 구성
- `SecurityConfig`에서 List.of(...) 방식으로 CORS 도메인 적용
- `WebSocketConfig`에서 배열 그대로 setAllowedOrigins 처리
- dev.yml은 .gitignore 대상이라 미포함
- prod.yml에는 아직 실제 서비스 도메인 미적용 (향후 배포 환경에 따라 추가 예정)

### 기타
- 추후 CORS 관련 도메인 추가는 `application-prod.yml` 기준으로 진행
- application-dev.yml 포맷은 배열 기반 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * CORS 허용 오리진을 외부 설정 파일에서 관리할 수 있도록 설정 기능이 추가되었습니다.

* **개선 사항**
  * 보안 및 웹소켓 설정에서 허용 오리진 목록이 하드코딩 방식에서 외부 설정 기반으로 변경되었습니다.
  * 운영 환경 설정 파일(application-prod.yml)에 CORS 관련 설정 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->