### PR TITLE
[FEAT] 마이페이지 프로필 이지미 변경 및 이름 변경 추가

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
@@ -34,10 +34,17 @@ public class UploadPathUtil {
     }
 
     public static String extractPathFromPublicUrl(String bucket, String publicUrl) {
-        final String marker = "/storage/v1/object/public/" + bucket + "/";
-        URI uri = URI.create(publicUrl);
-        String path = uri.getPath();
-        int idx = path.indexOf(marker);
-        return (idx != -1) ? path.substring(idx + marker.length()) : null;
+        if (bucket == null || bucket.isEmpty() || publicUrl == null || publicUrl.isEmpty())
+            return null;
+
+        try {
+            final String marker = "/storage/v1/object/public/" + bucket + "/";
+            URI uri = URI.create(publicUrl);
+            String path = uri.getPath();
+            int idx = path.indexOf(marker);
+            return (idx != -1) ? path.substring(idx + marker.length()) : null;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/UploadPathUtil.java
@@ -1,5 +1,6 @@
 package com.team03.ticketmon._global.util;
 
+import java.net.URI;
 import java.util.Map;
 
 public class UploadPathUtil {
@@ -30,5 +31,13 @@ public class UploadPathUtil {
             throw new IllegalArgumentException("지원하지 않는 MIME 타입입니다: " + mimeType);
         }
         return extension;
+    }
+
+    public static String extractPathFromPublicUrl(String bucket, String publicUrl) {
+        final String marker = "/storage/v1/object/public/" + bucket + "/";
+        URI uri = URI.create(publicUrl);
+        String path = uri.getPath();
+        int idx = path.indexOf(marker);
+        return (idx != -1) ? path.substring(idx + marker.length()) : null;
     }
 }

--- a/src/main/java/com/team03/ticketmon/_global/util/uploader/StorageUploader.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/uploader/StorageUploader.java
@@ -18,4 +18,5 @@ public interface StorageUploader {
      * @return 업로드된 파일의 URL 또는 경로
      */
     String uploadFile(MultipartFile file, String bucket, String path);
+    void deleteFile(String bucket, String fullPath);
 }

--- a/src/main/java/com/team03/ticketmon/_global/util/uploader/s3/S3Uploader.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/uploader/s3/S3Uploader.java
@@ -32,5 +32,11 @@ public class S3Uploader implements StorageUploader {
         // TODO: S3 마이그레이션 시 실제 S3 업로드 로직을 구현
         throw new UnsupportedOperationException("아직 S3 업로드는 구현되지 않았습니다.");
     }
+
+    @Override
+    public void deleteFile(String bucket, String fullPath) {
+        // TODO: S3 마이그레이션 시 실제 S3 파일 삭제 로직을 구현
+        throw new UnsupportedOperationException("아직 S3 업로드는 구현되지 않았습니다.");
+    }
 }
 

--- a/src/main/java/com/team03/ticketmon/_global/util/uploader/supabase/SupabaseUploader.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/uploader/supabase/SupabaseUploader.java
@@ -1,10 +1,10 @@
 package com.team03.ticketmon._global.util.uploader.supabase;
 
 import com.team03.ticketmon._global.exception.StorageUploadException;
+import com.team03.ticketmon._global.util.UploadPathUtil;
 import com.team03.ticketmon._global.util.uploader.StorageUploader;
 import io.supabase.StorageClient;
-//import io.supabase.common.SupabaseException;
-import io.supabase.errors.StorageException; // 1.1.0
+// import io.supabase.common.SupabaseException;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,8 +12,10 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -114,4 +116,26 @@ public class SupabaseUploader implements StorageUploader {
         }
     }
 
+    @Override
+    public void deleteFile(String bucket, String fullPath) {
+        try {
+            log.debug("✅ [DEBUG] SupabaseUploader 파일 삭제 시작");
+            log.debug("✅ [DEBUG] bucket = {}", bucket);
+            log.debug("✅ [DEBUG] fullPath = {}", fullPath);
+
+            String deletePath = UploadPathUtil.extractPathFromPublicUrl(bucket, fullPath);
+            log.debug("✅ [DEBUG] deletePath = {}", deletePath);
+
+            if (deletePath == null || deletePath.isEmpty()) {
+                log.warn("❗ Supabase 파일 삭제 실패: {}", fullPath);
+                throw new IllegalArgumentException("파일 경로 형식이 잘못되었습니다.");
+            }
+
+            storageClient.from(bucket).delete(List.of(deletePath)).get(); // 비동기 실행 블록
+            log.info("🗑️ Supabase 파일 삭제 성공: {}", fullPath);
+        } catch (InterruptedException | ExecutionException e) {
+            log.warn("❗ Supabase 파일 삭제 실패: {}", fullPath, e);
+            throw new StorageUploadException("파일 삭제 실패", e);
+        }
+    }
 }

--- a/src/main/java/com/team03/ticketmon/user/controller/MyPageAPIController.java
+++ b/src/main/java/com/team03/ticketmon/user/controller/MyPageAPIController.java
@@ -47,7 +47,7 @@ public class MyPageAPIController {
     @ApiResponse(responseCode = "401", description = "사용자 권한 인증 실패")
     public ResponseEntity<?> updateUserProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Validated @ModelAttribute("user") UpdateUserProfileDTO dto,
+            @Validated @ModelAttribute UpdateUserProfileDTO dto,
             BindingResult bindingResult) {
 
         if (userDetails == null)

--- a/src/main/java/com/team03/ticketmon/user/dto/UpdateUserProfileDTO.java
+++ b/src/main/java/com/team03/ticketmon/user/dto/UpdateUserProfileDTO.java
@@ -2,8 +2,11 @@ package com.team03.ticketmon.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateUserProfileDTO(
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        String name,
         @NotBlank(message = "사용자 닉네임은 필수입니다.")
         String nickname,
         @Pattern(
@@ -13,6 +16,6 @@ public record UpdateUserProfileDTO(
         String phone,
         @NotBlank(message = "사용자 주소는 필수입니다.")
         String address,
-        String profileImage
+        MultipartFile profileImage
 ) {
 }

--- a/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
@@ -19,6 +19,7 @@ public class MyPageServiceImpl implements MyPageService {
 
     private final UserEntityService userEntityService;
     private final PasswordEncoder passwordEncoder;
+    private final UserProfileService userProfileService;
 
     @Override
     public UserProfileDTO getUserProfile(Long userId) {
@@ -42,10 +43,16 @@ public class MyPageServiceImpl implements MyPageService {
         UserEntity user = userEntityService.findUserEntityByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
 
+        if (!user.getProfileImage().isEmpty() && dto.profileImage() != null)
+            userProfileService.deleteProfileImage(user.getProfileImage());
+
+        String profileImageUrl = userProfileService.uploadProfileAndReturnUrl(dto.profileImage());
+
+        user.setName(dto.name());
         user.setNickname(dto.nickname());
         user.setPhone(dto.phone());
         user.setAddress(dto.address());
-        user.setProfileImage(dto.profileImage());
+        user.setProfileImage(profileImageUrl);
 
         userEntityService.save(user);
         log.info("회원 정보 변경 성공 : userId={}", userId);

--- a/src/main/java/com/team03/ticketmon/user/service/UserProfileService.java
+++ b/src/main/java/com/team03/ticketmon/user/service/UserProfileService.java
@@ -4,4 +4,5 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface UserProfileService {
     String uploadProfileAndReturnUrl(MultipartFile profileImage);
+    void deleteProfileImage(String profileImageUrl);
 }

--- a/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/UserProfileServiceImpl.java
@@ -37,4 +37,12 @@ public class UserProfileServiceImpl implements UserProfileService {
 
         return storageUploader.uploadFile(profileImage, supabaseProperties.getProfileBucket(), filePath);
     }
+
+    @Override
+    public void deleteProfileImage(String profileImageUrl) {
+        if (profileImageUrl == null || profileImageUrl.isEmpty())
+            return;
+
+        storageUploader.deleteFile(supabaseProperties.getProfileBucket(), profileImageUrl);
+    }
 }


### PR DESCRIPTION
# 🖼️ [프로필 이미지] 업로드 및 삭제 기능 구현

## 작업 내용

* [x] 프로필 이미지 파일 업로드 기능 구현
* [x] 기존 프로필 이미지 삭제 기능 구현
* [x] Supabase Storage 파일 삭제 로직 구현
* [x] 프로필 업데이트 시 이미지 처리 로직 개선
* [x] 파일 경로 추출 유틸리티 메서드 추가

## 주요 변경사항

### **수정된 파일**:
* **`UploadPathUtil.java`**: Supabase public URL에서 파일 경로를 추출하는 `extractPathFromPublicUrl` 메서드 추가
* **`StorageUploader.java`**: 파일 삭제를 위한 `deleteFile` 인터페이스 메서드 추가
* **`S3Uploader.java`**: S3 파일 삭제 메서드 스켈레톤 구현 (TODO 상태)
* **`SupabaseUploader.java`**: Supabase Storage 파일 삭제 로직 구현 및 상세 로깅 추가
* **`MyPageAPIController.java`**: `@ModelAttribute` 어노테이션에서 불필요한 name 속성 제거
* **`UpdateUserProfileDTO.java`**: 프로필 이미지 필드 타입을 `String`에서 `MultipartFile`로 변경하고 `name` 필드 추가
* **`MyPageServiceImpl.java`**: 프로필 업데이트 시 기존 이미지 삭제 및 새 이미지 업로드 로직 구현
* **`UserProfileService.java`**: 프로필 이미지 삭제를 위한 `deleteProfileImage` 메서드 추가
* **`UserProfileServiceImpl.java`**: 프로필 이미지 삭제 로직 구현

### **핵심 개선사항**:
- 프로필 이미지 업데이트 시 기존 이미지 자동 삭제로 스토리지 용량 최적화
- Supabase public URL 파싱을 통한 정확한 파일 경로 추출
- 파일 삭제 실패 시 적절한 예외 처리 및 로깅
- DTO 타입 안정성 개선 (`String` → `MultipartFile`)

## 보안 확인사항

* [x] 민감정보 환경변수 처리 (Supabase 설정은 기존 구현 활용)
* [x] 입력값 validation 어노테이션 적용 (`@NotBlank`, `@Pattern` 등)
* [x] 에러 핸들링 시 내부 정보 노출 방지 (StorageUploadException으로 래핑)
* [x] 파일 경로 검증을 통한 임의 파일 삭제 방지
* [x] MultipartFile 처리 시 적절한 예외 처리

## 테스트 가이드

1. 새 프로필 이미지 업로드 시 정상 동작 확인
2. 기존 프로필 이미지가 있는 상태에서 새 이미지 업로드 시 기존 이미지 삭제 확인
3. 잘못된 파일 형식 업로드 시 적절한 에러 메시지 표시 확인
4. Supabase Storage에서 파일 삭제 로그 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프로필 이미지 삭제 기능이 추가되어, 기존 이미지를 새 이미지로 교체 시 자동으로 삭제됩니다.
  * 프로필 이미지 업로드 방식이 파일 업로드(MultipartFile)로 변경되었습니다.
  * 저장소에서 파일 삭제 기능이 추가되어, 프로필 이미지 삭제 시 활용됩니다.

* **버그 수정**
  * 사용자 이름(name) 입력이 필수로 변경되어, 빈 값 입력 시 오류가 발생합니다.

* **기타**
  * 프로필 수정 시 이름, 프로필 이미지, 닉네임, 전화번호, 주소가 모두 정상적으로 업데이트됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->