### PR TITLE
[FIX] 마이페이지 프로필 업데이트 로직  수정

### DIFF
--- a/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
@@ -43,18 +43,19 @@ public class MyPageServiceImpl implements MyPageService {
         UserEntity user = userEntityService.findUserEntityByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
 
-        if (user.getProfileImage() != null && !user.getProfileImage().isEmpty() && dto.profileImage() != null)
-            userProfileService.deleteProfileImage(user.getProfileImage());
+        if (dto.profileImage() != null && !dto.profileImage().isEmpty()) {
+            // 기존 프로필 이미지가 있으면 저장소에서 삭제
+            if (user.getProfileImage() != null && !user.getProfileImage().isEmpty())
+                userProfileService.deleteProfileImage(user.getProfileImage());
 
-        String profileImageUrl = userProfileService.uploadProfileAndReturnUrl(dto.profileImage());
+            String profileImageUrl = userProfileService.uploadProfileAndReturnUrl(dto.profileImage());
+            user.setProfileImage(profileImageUrl);
+        }
 
         user.setName(dto.name());
         user.setNickname(dto.nickname());
         user.setPhone(dto.phone());
         user.setAddress(dto.address());
-
-        if (profileImageUrl != null && !profileImageUrl.isEmpty())
-            user.setProfileImage(profileImageUrl);
 
         userEntityService.save(user);
         log.info("회원 정보 변경 성공 : userId={}", userId);

--- a/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
@@ -43,7 +43,7 @@ public class MyPageServiceImpl implements MyPageService {
         UserEntity user = userEntityService.findUserEntityByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException("회원 정보가 없습니다."));
 
-        if (!user.getProfileImage().isEmpty() && dto.profileImage() != null)
+        if (user.getProfileImage() != null && !user.getProfileImage().isEmpty() && dto.profileImage() != null)
             userProfileService.deleteProfileImage(user.getProfileImage());
 
         String profileImageUrl = userProfileService.uploadProfileAndReturnUrl(dto.profileImage());

--- a/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
+++ b/src/main/java/com/team03/ticketmon/user/service/MyPageServiceImpl.java
@@ -52,7 +52,9 @@ public class MyPageServiceImpl implements MyPageService {
         user.setNickname(dto.nickname());
         user.setPhone(dto.phone());
         user.setAddress(dto.address());
-        user.setProfileImage(profileImageUrl);
+
+        if (profileImageUrl != null && !profileImageUrl.isEmpty())
+            user.setProfileImage(profileImageUrl);
 
         userEntityService.save(user);
         log.info("회원 정보 변경 성공 : userId={}", userId);


### PR DESCRIPTION
- 프로필 업로드 Null Pointer Exception 수정
- 프로필 이미지 변경 시에만 프로필 업데이트 할 수 있도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로필 이미지 업데이트 시, 기존 이미지가 null인 경우를 추가로 확인하여 예외 발생을 방지했습니다.
  * 새 프로필 이미지 URL이 null 또는 비어있을 때 기존 프로필 이미지가 덮어써지지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->