### PR TITLE
[FEAT] 대기열 시스템 아키텍처 개선 및 실시간 상호작용 기능 강화

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -4,10 +4,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.auth.jwt.*;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import jakarta.servlet.DispatcherType;
-import org.redisson.api.RedissonClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -66,9 +65,8 @@ public class SecurityConfig {
 	private final UserEntityService userEntityService;
 	private final SocialUserService socialUserService;
 	private final CookieUtil cookieUtil;
-    private final RedissonClient redissonClient;
-    private final RedisKeyGenerator keyGenerator;
 	private final CorsProperties corsProperties;
+	private final QueueRedisAdapter queueRedisAdapter;
 
 	/**
 	 * <b>AuthenticationManager 빈 설정</b> <br>
@@ -187,7 +185,7 @@ public class SecurityConfig {
 				LogoutFilter.class)
 			.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), cookieUtil),
 				UsernamePasswordAuthenticationFilter.class)
-            .addFilterAfter(new AccessKeyFilter(redissonClient, keyGenerator), JwtAuthenticationFilter.class)
+            .addFilterAfter(new AccessKeyFilter(queueRedisAdapter), JwtAuthenticationFilter.class)
 
 			// 인증/인가 실패(인증 실패(401), 권한 부족(403)) 시 반환되는 예외 응답 설정
 			.exceptionHandling(exception -> exception

--- a/src/main/java/com/team03/ticketmon/_global/exception/ErrorCode.java
+++ b/src/main/java/com/team03/ticketmon/_global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     INVALID_PAGE_SIZE(400, "C005", "페이지 크기는 1-100 사이여야 합니다."), // 추가: 페이징 검증
     INVALID_PAGE_REQUEST(400, "C006", "페이징 요청 정보가 유효하지 않습니다."), // 추가: Pageable 검증
     REQUEST_PARAM_MISSING(400, "C007", "필수 요청 파라미터가 누락되었습니다."), // <--- 추가됨
+    REDIS_COMMAND_FAILED(500, "C008", "REDIS_COMMAND_FAILED"),
 
     // 추가: File (파일 업로드/처리 관련) - 새로운 카테고리
     FILE_UPLOAD_FAILED(500, "F001", "파일 업로드 중 알 수 없는 오류가 발생했습니다."), // 파일 업로드 오류

--- a/src/main/java/com/team03/ticketmon/_global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/RedisKeyGenerator.java
@@ -115,6 +115,12 @@ public class RedisKeyGenerator {
     public static final String ADMISSION_TOPIC = "admission-channel";
 
     /**
+     * 📣 `rank-update-channel`<br>
+     * 순위 업데이트 이벤트를 전달하는 Redis Pub/Sub 채널 이름입니다.<br>
+     */
+    public static final String RANK_UPDATE_TOPIC = "rank-update-channel";
+
+    /**
      * 🎯 콘서트별 대기열 키 생성
      * @param concertId 콘서트 ID
      * @return Redis 키: `waitqueue:concert:{concertId}`

--- a/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
+++ b/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
@@ -11,6 +11,11 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
+/**
+ * 대기열 도메인의 Redis 데이터 접근을 전담하는 어댑터 클래스
+ * 이 클래스는 서비스 계층과 데이터 인프라(Redis) 사이의 결합도를 낮추고,
+ * Redis 관련 책임을 중앙에서 관리합니다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -30,7 +35,6 @@ public class QueueRedisAdapter {
      */
     public long generateQueueScore(Long concertId) {
         long timestamp = System.currentTimeMillis();
-
         String queueKey = keyGenerator.getWaitQueueKey(concertId);
         String sequenceKey = queueKey + SEQUENCE_KEY_SUFFIX + timestamp;
 
@@ -38,7 +42,7 @@ public class QueueRedisAdapter {
         long currentSequence = sequence.incrementAndGet();
 
         if (sequence.remainTimeToLive() == -1) {
-            sequence.expire(Duration.ofMillis(100));
+            sequence.expire(Duration.ofMillis(200));
         }
 
         if (currentSequence > MAX_SEQUENCE) {
@@ -51,7 +55,7 @@ public class QueueRedisAdapter {
 
     /**
      * 특정 콘서트의 대기열(Sorted Set) 객체를 반환
-     * 외부 서비스(스케줄러 등)에서 대기열의 상태를 조회할 때 사용됩니다.
+     * 외부 서비스(스케줄러 등)에서 대기열의 상태를 조회할 때 사용
      *
      * @param concertId 조회할 콘서트의 ID
      * @return 해당 콘서트의 대기열 RScoredSortedSet 객체
@@ -62,7 +66,7 @@ public class QueueRedisAdapter {
     }
 
     /**
-     * 특정 콘서트의 활성 사용자 수(AtomicLong) 객체를 반환합니다.
+     * 특정 콘서트의 활성 사용자 수(AtomicLong) 객체를 반환
      */
     public RAtomicLong getActiveUserCounter(Long concertId) {
         String countKey = keyGenerator.getActiveUsersCountKey(concertId);
@@ -70,7 +74,7 @@ public class QueueRedisAdapter {
     }
 
     /**
-     * 특정 콘서트의 활성 세션(Sorted Set) 객체를 반환합니다.
+     * 특정 콘서트의 활성 세션(Sorted Set) 객체를 반환
      */
     public RScoredSortedSet<Long> getActiveSessions(Long concertId) {
         String sessionsKey = keyGenerator.getActiveSessionsKey(concertId);
@@ -78,7 +82,7 @@ public class QueueRedisAdapter {
     }
 
     /**
-     * 사용자의 특정 콘서트의 accessKey(Bucket) 객체를 반환합니다.
+     * 사용자의 특정 콘서트의 accessKey(Bucket) 객체를 반환
      */
     public RBucket<String> getAccessKeyBucket(Long concertId, Long userId) {
         String accessKey = keyGenerator.getAccessKey(concertId, userId);

--- a/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
+++ b/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
@@ -37,8 +37,8 @@ public class QueueRedisAdapter {
         RAtomicLong sequence = redissonClient.getAtomicLong(sequenceKey);
         long currentSequence = sequence.incrementAndGet();
 
-        if (currentSequence == 1) {
-            sequence.expire(Duration.ofSeconds(2));
+        if (sequence.remainTimeToLive() == -1) {
+            sequence.expire(Duration.ofMillis(100));
         }
 
         if (currentSequence > MAX_SEQUENCE) {

--- a/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
+++ b/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
@@ -1,0 +1,110 @@
+package com.team03.ticketmon.queue.adapter;
+
+import com.team03.ticketmon._global.exception.BusinessException;
+import com.team03.ticketmon._global.exception.ErrorCode;
+import com.team03.ticketmon._global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.*;
+import org.redisson.client.codec.LongCodec;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueRedisAdapter {
+    private final RedissonClient redissonClient;
+    private final RedisKeyGenerator keyGenerator;
+
+    private static final String SEQUENCE_KEY_SUFFIX = ":seq:";
+    private static final int SEQUENCE_BITS = 21;
+    private static final long MAX_SEQUENCE = (1L << SEQUENCE_BITS) - 1;
+
+    /**
+     * 타임스탬프와 원자적 시퀀스를 조합하여 유니크한 대기열 점수(score)를 생성
+     * 대기열 점수 생성에 대한 모든 책임
+     * @param concertId 점수를 생성할 콘서트 ID
+     * @return 생성된 유니크한 점수(long)
+     */
+    public long generateQueueScore(Long concertId) {
+        long timestamp = System.currentTimeMillis();
+
+        String queueKey = keyGenerator.getWaitQueueKey(concertId);
+        String sequenceKey = queueKey + SEQUENCE_KEY_SUFFIX + timestamp;
+
+        RAtomicLong sequence = redissonClient.getAtomicLong(sequenceKey);
+        long currentSequence = sequence.incrementAndGet();
+
+        if (currentSequence == 1) {
+            sequence.expire(Duration.ofSeconds(2));
+        }
+
+        if (currentSequence > MAX_SEQUENCE) {
+            log.error("1ms 내 요청 한도 초과! ({}개 이상)", MAX_SEQUENCE);
+            throw new BusinessException(ErrorCode.QUEUE_TOO_MANY_REQUESTS);
+        }
+
+        return (timestamp << SEQUENCE_BITS) | currentSequence;
+    }
+
+    /**
+     * 특정 콘서트의 대기열(Sorted Set) 객체를 반환
+     * 외부 서비스(스케줄러 등)에서 대기열의 상태를 조회할 때 사용됩니다.
+     *
+     * @param concertId 조회할 콘서트의 ID
+     * @return 해당 콘서트의 대기열 RScoredSortedSet 객체
+     */
+    public RScoredSortedSet<Long> getQueue(Long concertId) {
+        String queueKey = keyGenerator.getWaitQueueKey(concertId);
+        return redissonClient.getScoredSortedSet(queueKey, LongCodec.INSTANCE);
+    }
+
+    /**
+     * 특정 콘서트의 활성 사용자 수(AtomicLong) 객체를 반환합니다.
+     */
+    public RAtomicLong getActiveUserCounter(Long concertId) {
+        String countKey = keyGenerator.getActiveUsersCountKey(concertId);
+        return redissonClient.getAtomicLong(countKey);
+    }
+
+    /**
+     * 특정 콘서트의 활성 세션(Sorted Set) 객체를 반환합니다.
+     */
+    public RScoredSortedSet<Long> getActiveSessions(Long concertId) {
+        String sessionsKey = keyGenerator.getActiveSessionsKey(concertId);
+        return redissonClient.getScoredSortedSet(sessionsKey, LongCodec.INSTANCE);
+    }
+
+    /**
+     * 사용자의 특정 콘서트의 accessKey(Bucket) 객체를 반환합니다.
+     */
+    public RBucket<String> getAccessKeyBucket(Long concertId, Long userId) {
+        String accessKey = keyGenerator.getAccessKey(concertId, userId);
+        return redissonClient.getBucket(accessKey);
+    }
+
+    public RLock getAdmissionSchedulerLock() {
+        String key = RedisKeyGenerator.ADMISSION_SCHEDULER_LOCK_KEY;
+        return redissonClient.getLock(key);
+    }
+
+    public RLock getCleanupSchedulerLock() {
+        String key = RedisKeyGenerator.CLEANUP_SCHEDULER_LOCK_KEY;
+        return redissonClient.getLock(key);
+    }
+
+    public RLock getConsistencyCheckLock() {
+        String key = RedisKeyGenerator.CONSISTENCY_CHECK_LOCK_KEY;
+        return redissonClient.getLock(key);
+    }
+
+    public RTopic getAdmissionTopic() {
+        return redissonClient.getTopic(RedisKeyGenerator.ADMISSION_TOPIC);
+    }
+
+    public RTopic getRankUpdateTopic() {
+        return redissonClient.getTopic(RedisKeyGenerator.RANK_UPDATE_TOPIC);
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/domain/QueueStatus.java
+++ b/src/main/java/com/team03/ticketmon/queue/domain/QueueStatus.java
@@ -1,0 +1,9 @@
+package com.team03.ticketmon.queue.domain;
+
+public enum QueueStatus {
+    WAITING,                // 대기 중
+    IMMEDIATE_ENTRY,        // 즉시 입장 가능
+    ADMITTED,               // 입장 허가된 상태
+    ERROR,                  // 에러 발생
+    EXPIRED_OR_NOT_IN_QUEUE // 대기열에 없거나 만료됨
+}

--- a/src/main/java/com/team03/ticketmon/queue/dto/QueueStatusDto.java
+++ b/src/main/java/com/team03/ticketmon/queue/dto/QueueStatusDto.java
@@ -1,34 +1,22 @@
 package com.team03.ticketmon.queue.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.team03.ticketmon.queue.domain.QueueStatus;
 
 /**
- * ✅ EnterResponse: 대기열 진입 통합 응답 DTO<br>
+ * ✅ QueueStatusDto: 대기열 관련 통합 응답 DTO<br>
  * -----------------------------------------------------<br>
- * 대기열 진입 요청에 대한 상태, 순위, 접근 키, 메시지를 포함한 응답을 제공합니다.<br><br>
- *
- * 📌 상태(status):
- * <ul>
- *     <li>WAITING         : 대기열에 등록된 경우</li>
- *     <li>IMMEDIATE_ENTRY : 즉시 입장이 가능한 경우</li>
- *     <li>ERROR           : 에러 발생 시</li>
- * </ul>
- *
- * 📌 필드 설명:
- * <ul>
- *     <li>status    : 응답 상태</li>
- *     <li>rank      : 대기열 순위 (status가 WAITING일 때만 유효)</li>
- *     <li>accessKey : 즉시 입장 키 (status가 IMMEDIATE_ENTRY일 때만 유효)</li>
- *     <li>message   : 사용자 안내 메시지</li>
- * </ul>
+ * 대기열 관련 요청에 대한 상태, 순위, 접근 키, 메시지를 포함한 응답을 제공<br>
+ * 정적 팩토리 메서드를 통해 객체 생성을 단순화하고 일관성을 유지
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record QueueStatusDto(
-        String status,     // "WAITING", "IMMEDIATE_ENTRY", "ERROR"
-        Long rank,         // status가 "WAITING"일 때만 값을 가짐
-        String accessKey,  // status가 "IMMEDIATE_ENTRY"일 때만 값을 가짐
-        String message     // 사용자에게 보여줄 메시지 (에러 또는 안내)
+        QueueStatus status,
+        Long rank,
+        String accessKey,
+        String message
 ) {
+
     /**
      * ✅ 정적 팩토리 메서드: 대기열 등록 응답 생성 (WAITING)
      *
@@ -36,7 +24,7 @@ public record QueueStatusDto(
      * @return EnterResponse 객체
      */
     public static QueueStatusDto waiting(Long rank) {
-        return new QueueStatusDto("WAITING", rank, null, "대기열에 정상적으로 등록되었습니다.");
+        return new QueueStatusDto(QueueStatus.WAITING, rank, null, "현재 대기 중입니다.");
     }
 
     /**
@@ -46,7 +34,26 @@ public record QueueStatusDto(
      * @return EnterResponse 객체
      */
     public static QueueStatusDto immediateEntry(String accessKey) {
-        return new QueueStatusDto("IMMEDIATE_ENTRY", null, accessKey, "즉시 입장이 가능합니다.");
+        return new QueueStatusDto(QueueStatus.IMMEDIATE_ENTRY, null, accessKey, "즉시 입장이 가능합니다.");
+    }
+
+    /**
+     * [신규] ✅ 정적 팩토리 메서드: 입장 허가 응답 생성 (ADMITTED)
+     * 이미 입장 허가를 받은 사용자의 상태를 조회했을 때 사용됩니다.
+     * @param accessKey 사용자에게 부여된 접근 키
+     * @return QueueStatusDto 객체
+     */
+    public static QueueStatusDto admitted(String accessKey) {
+        return new QueueStatusDto(QueueStatus.ADMITTED, null, accessKey, "입장이 허가된 상태입니다.");
+    }
+
+    /**
+     * [신규] ✅ 정적 팩토리 메서드: 대기열 이탈/만료 응답 생성 (EXPIRED_OR_NOT_IN_QUEUE)
+     * 대기열에 정보가 없거나 만료된 사용자의 상태를 조회했을 때 사용됩니다.
+     * @return QueueStatusDto 객체
+     */
+    public static QueueStatusDto expiredOrNotInQueue() {
+        return new QueueStatusDto(QueueStatus.EXPIRED_OR_NOT_IN_QUEUE, null, null, "대기열에 정보가 없거나 만료되었습니다.");
     }
 
     /**
@@ -56,6 +63,6 @@ public record QueueStatusDto(
      * @return EnterResponse 객체
      */
     public static QueueStatusDto error(String message) {
-        return new QueueStatusDto("ERROR", null, null, message);
+        return new QueueStatusDto(QueueStatus.ERROR, null, null, message);
     }
 }

--- a/src/main/java/com/team03/ticketmon/queue/dto/RankUpdateEvent.java
+++ b/src/main/java/com/team03/ticketmon/queue/dto/RankUpdateEvent.java
@@ -1,0 +1,9 @@
+package com.team03.ticketmon.queue.dto;
+
+/**
+ * ✅ RankUpdateEvent: 사용자 순위 업데이트 이벤트 DTO<br>
+ * -----------------------------------------------------<br>
+ * Redis Pub/Sub 채널을 통해 특정 사용자에게 현재 대기 순위를 전달합니다.<br><br>
+ */
+public record RankUpdateEvent(Long userId, int rank) {
+}

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/CleanupScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/CleanupScheduler.java
@@ -1,12 +1,13 @@
 package com.team03.ticketmon.queue.scheduler;
 
-import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.concert.domain.enums.ConcertStatus;
 import com.team03.ticketmon.concert.repository.ConcertRepository;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.*;
-import org.redisson.client.codec.LongCodec;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RLock;
+import org.redisson.api.RScoredSortedSet;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,14 +20,13 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class CleanupScheduler {
 
-    private final RedissonClient redissonClient;
     private final ConcertRepository concertRepository;
-    private final RedisKeyGenerator keyGenerator;
-
+    private final QueueRedisAdapter queueRedisAdapter;
 
     @Scheduled(fixedDelay = 10000)
     public void cleanupExpiredSessions() {
-        RLock lock = redissonClient.getLock(RedisKeyGenerator.CLEANUP_SCHEDULER_LOCK_KEY);
+        RLock lock = queueRedisAdapter.getCleanupSchedulerLock();
+
         try {
             // 1. 분산 락 획득 시도
             boolean isLocked = lock.tryLock(100, 5, TimeUnit.SECONDS);
@@ -46,8 +46,7 @@ public class CleanupScheduler {
 
             // 3. 각 콘서트별로 세션 정리 작업을 수행
             for (Long concertId : activeConcertIds) {
-                String activeSessionsKey = keyGenerator.getActiveSessionsKey(concertId);
-                RScoredSortedSet<Long> activeSessions = redissonClient.getScoredSortedSet(activeSessionsKey, LongCodec.INSTANCE);
+                RScoredSortedSet<Long> activeSessions = queueRedisAdapter.getActiveSessions(concertId);
 
                 // 락이 걸려 있으므로, '조회'와 '삭제'를 순차적으로 실행해도 안전
                 // 3-1. 만료된 멤버들을 조회
@@ -62,15 +61,14 @@ public class CleanupScheduler {
 
                     // 3-3. 활성 사용자 수 감소
                     long expiredCount = expiredUserIds.size();
-                    String activeUserCountKey = keyGenerator.getActiveUsersCountKey(concertId);
-                    RAtomicLong atomicCount = redissonClient.getAtomicLong(activeUserCountKey);
+                    RAtomicLong activeUserCounter = queueRedisAdapter.getActiveUserCounter(concertId);
 
                     // compareAndSet을 이용한 원자적 업데이트 루프
                     long prevValue, nextValue;
                     do {
-                        prevValue = atomicCount.get();
+                        prevValue = activeUserCounter.get();
                         nextValue = Math.max(0, prevValue - expiredCount);
-                    } while (!atomicCount.compareAndSet(prevValue, nextValue));
+                    } while (!activeUserCounter.compareAndSet(prevValue, nextValue));
 
                     log.info("[콘서트 ID: {}] {}개의 세션 정리 완료. 남은 활성 사용자 수: {}", concertId, expiredCount, nextValue);
                 }

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/ConsistencyCheckScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/ConsistencyCheckScheduler.java
@@ -1,13 +1,13 @@
 package com.team03.ticketmon.queue.scheduler;
 
-import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.concert.domain.enums.ConcertStatus;
 import com.team03.ticketmon.concert.repository.ConcertRepository;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RAtomicLong;
 import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
+import org.redisson.api.RScoredSortedSet;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,32 +18,31 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class ConsistencyCheckScheduler {
 
-    private final RedissonClient redissonClient;
     private final ConcertRepository concertRepository;
-    private final RedisKeyGenerator keyGenerator;
+    private final QueueRedisAdapter queueRedisAdapter;
 
     /**
-     * 1시간마다 실행되어 활성 사용자 수와 실제 세션 수의 정합성을 체크하고 보정합니다.
+     * 1분마다 실행되어 활성 사용자 수와 실제 세션 수의 정합성을 체크하고 보정합니다.
      * TODO: 설정(cron, lock 타임아웃 등) application.yml 분리
      */
-    @Scheduled(cron = "0 0 * * * *") // 매시 정각에 실행
+    @Scheduled(fixedDelay = 60000)
     public void checkAndSyncCounts() {
-        RLock lock = redissonClient.getLock(RedisKeyGenerator.CONSISTENCY_CHECK_LOCK_KEY);
+        RLock lock = queueRedisAdapter.getConsistencyCheckLock();
 
         try {
             boolean isLocked = lock.tryLock(10, 60, TimeUnit.SECONDS);
             if (!isLocked) {
-                log.info("다른 인스턴스에서 정합성 체크 스케줄러가 실행 중입니다.");
+                log.debug("다른 인스턴스에서 정합성 체크 스케줄러가 실행 중입니다.");
                 return;
             }
 
-            log.info("===== 데이터 정합성 체크 스케줄러 시작 =====");
+            log.debug("===== 데이터 정합성 체크 스케줄러 시작 =====");
 
             // TODO [성능개선]: 활성화된 대기열 ID를 DB가 아니라 Redis에서 직접 조회하는 방법 검토
             concertRepository.findConcertIdsByStatus(ConcertStatus.ON_SALE)
                     .forEach(this::syncConcertCounts);
 
-            log.info("===== 데이터 정합성 체크 스케줄러 종료 =====");
+            log.debug("===== 데이터 정합성 체크 스케줄러 종료 =====");
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -57,12 +56,10 @@ public class ConsistencyCheckScheduler {
 
     // TODO [배치처리]: 네트워크 왕복 최소화를 위해 Redisson Batch API 적용
     private void syncConcertCounts(Long concertId) {
-        String activeSessionsKey = keyGenerator.getActiveSessionsKey(concertId);
-        String countKey = keyGenerator.getActiveUsersCountKey(concertId);
+        RScoredSortedSet<Long> activeSessions = queueRedisAdapter.getActiveSessions(concertId);
+        RAtomicLong counter = queueRedisAdapter.getActiveUserCounter(concertId);
 
-        RAtomicLong counter = redissonClient.getAtomicLong(countKey);
-
-        long actualSessionSize = redissonClient.getScoredSortedSet(activeSessionsKey).size();
+        long actualSessionSize = activeSessions.size();
         long storedCnt  = counter.get();
 
         if (actualSessionSize != storedCnt) {

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
@@ -3,6 +3,7 @@ package com.team03.ticketmon.queue.scheduler;
 import com.team03.ticketmon._global.util.RedisKeyGenerator;
 import com.team03.ticketmon.concert.domain.enums.ConcertStatus;
 import com.team03.ticketmon.concert.repository.ConcertRepository;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import com.team03.ticketmon.queue.service.AdmissionService;
 import com.team03.ticketmon.queue.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
@@ -26,19 +27,15 @@ import java.util.concurrent.TimeUnit;
 public class WaitingQueueScheduler {
 
     private final WaitingQueueService waitingQueueService;
-    private final RedissonClient redissonClient;
     private final ConcertRepository concertRepository;
     private final AdmissionService admissionService;
+    private final QueueRedisAdapter queueRedisAdapter;
 
     @Value("${app.queue.max-active-users}")
     private long maxActiveUsers; // 시스템이 동시에 수용 가능한 최대 활성 사용자 수
 
     @Value("${app.queue.top-ranker-count}")
     private long topRankerCount ; // 최상위 대기자 기준 설정
-
-    // --- Redis 키 정의 ---
-    /** 분산 락을 위한 키. 이 락을 획득한 인스턴스만이 스케줄러 로직을 실행. */
-    private static final String ADMISSION_LOCK_KEY = RedisKeyGenerator.ADMISSION_SCHEDULER_LOCK_KEY;
 
     /**
      * 10초마다 주기적으로 실행되어 대기열을 처리.
@@ -49,7 +46,8 @@ public class WaitingQueueScheduler {
     public void execute() {
 
         // 분산 락 획득 시도
-        RLock lock = redissonClient.getLock(ADMISSION_LOCK_KEY);
+        RLock lock = queueRedisAdapter.getAdmissionSchedulerLock();
+
         try {
             // [분산 락 획득 시도]
             // waitTime(0): waitTime을 0으로 두어, 락 획득에 실패하면 즉시 리턴하는 비대기 모드는 유지
@@ -96,8 +94,7 @@ public class WaitingQueueScheduler {
     private void processQueueForConcert(Long concertId) {
         log.debug("===== [콘서트 ID: {}] 대기열 처리 시작. =====", concertId);
 
-        String activeUserCountKey = "active_users_count:concert:" + concertId;
-        RAtomicLong activeUsersCount = redissonClient.getAtomicLong(activeUserCountKey);
+        RAtomicLong activeUsersCount = queueRedisAdapter.getActiveUserCounter(concertId);
         long currentActiveUsers = activeUsersCount.get();
         // TODO: maxActiveUsers도 콘서트별로 다르게 설정할 수 있도록 DB에서 가져오는 로직 추가 가능 (우선순위: 최하)
         long availableSlots = maxActiveUsers - currentActiveUsers;
@@ -119,30 +116,5 @@ public class WaitingQueueScheduler {
 
         // 추출된 사용자들에게 입장 허가 처리
         admissionService.grantAccess(concertId, admittedUserIds, true);
-
-
-        // ==================== 계층적 업데이트 로직 ====================
-//        RScoredSortedSet<Long> queue = waitingQueueService.getQueue(concertId);
-//
-//        // [STEP 6] Tier 1: 최상위 대기자 1,000명의 ID와 순위를 조회
-//        Collection<ScoredEntry<Long>> topRankers = queue.entryRange(0, TOP_RANKER_COUNT - 1);
-//
-//        int rank = 1;
-//        for (ScoredEntry<Long> entry : topRankers) {
-//            Long userId = entry.getValue();
-//            // 개인화된 순위 정보를 1:1 메시지로 전송
-//            notificationService.sendRankUpdate(userId, rank++);
-//        }
-//
-//        // [STEP 7] Tier 2: 중위권 포함 전체 대기자에게 그룹 정보 브로드캐스팅
-//        long totalWaitingCount = queue.size();
-//        notificationService.broadcastQueueStatus(concertId, totalWaitingCount);
-
-        // [STEP 8] Tier 3: 마일스톤 달성자 알림 (심화)
-        // 이전 스케줄 실행 시점의 1001등 사용자와 현재 1000등 사용자를 비교하여
-        // 새로 1000등 안에 진입한 사용자를 찾아내어 별도 알림을 보낼 수 있습니다.
-        // (구현 복잡도를 고려하여 초기에는 생략 가능)
-        // ===============================================================
-
     }
 }

--- a/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
+++ b/src/main/java/com/team03/ticketmon/queue/scheduler/WaitingQueueScheduler.java
@@ -35,9 +35,6 @@ public class WaitingQueueScheduler {
     @Value("${app.queue.max-active-users}")
     private long maxActiveUsers; // 시스템이 동시에 수용 가능한 최대 활성 사용자 수
 
-    @Value("${app.queue.top-ranker-count}")
-    private long topRankerCount ; // 최상위 대기자 기준 설정
-
     /**
      * 10초마다 주기적으로 실행되어 대기열을 처리.
      * fixedDelay는 이전 작업이 성공적으로 끝난 후 10초를 기다리는 것을 의미.

--- a/src/main/java/com/team03/ticketmon/queue/service/AdmissionService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/AdmissionService.java
@@ -3,8 +3,10 @@ package com.team03.ticketmon.queue.service;
 import com.team03.ticketmon._global.exception.BusinessException;
 import com.team03.ticketmon._global.exception.ErrorCode;
 import com.team03.ticketmon._global.util.RedisKeyGenerator;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RAtomicLong;
 import org.redisson.api.RBatch;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.LongCodec;
@@ -18,30 +20,43 @@ import java.util.List;
 import java.util.UUID;
 
 
+/**
+ * 사용자의 '입장(Admission)'과 관련된 핵심 비즈니스 로직을 처리하는 서비스
+ * - 원자적인 슬롯 점유 시도
+ * - 여러 사용자에 대한 동시 입장 처리 (AccessKey 발급, 세션 등록 등)
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdmissionService {
     private final RedissonClient redissonClient;
-    private final NotificationService notificationService;
     private final RedisKeyGenerator keyGenerator;
+
+    private final NotificationService notificationService;
+    private final QueueRedisAdapter queueRedisAdapter;
 
     @Value("${app.queue.access-key-ttl-minutes}")
     private long accessKeyTtlMinutes; // 발급된 입장 허가 키의 유효 시간 (분)
+    @Value("${app.queue.max-active-users}")
+    private long maxActiveUsers;
 
     /**
-     * 단일 사용자를 즉시 입장시킵니다.
-     * @param userId 사용자 ID
+     * 단일 사용자 즉시 입장
+     * 내부적으로 리스트 처리 메서드를 호출하여 코드 중복 방지
+     *
+     * @param concertId 입장시킬 콘서트 ID
+     * @param userId 입장시킬 사용자 ID
      * @return 발급된 AccessKey
      */
     public String grantAccess(Long concertId, Long userId) {
-        // 내부적으로 리스트 처리 메서드를 호출하여 코드 중복을 방지합니다.
         List<String> accessKeys = grantAccess(concertId, List.of(userId), false); // 즉시 입장은 알림을 보내지 않음
         return accessKeys.isEmpty() ? null : accessKeys.get(0);
     }
 
     /**
-     * 여러 사용자의 입장을 처리하고, 선택적으로 알림을 보냅니다.
+     * 여러 사용자의 입장을 처리하고, 선택적으로 알림을 전송
+     * Redis 파이프라이닝을 활용하기 위해 RBatch를 사용하여 여러 명령을 한 번에 전송
+     *
      * @param userIds 입장시킬 사용자 ID 리스트
      * @param sendNotification Redis Pub/Sub으로 알림을 보낼지 여부
      * @return 발급된 AccessKey 리스트
@@ -71,7 +86,8 @@ public class AdmissionService {
             // 1. AccessKey 저장
             String accessKeyRedisKey = keyGenerator.getAccessKey(concertId, userId);
             batch.getBucket(accessKeyRedisKey).setAsync(accessKey, ttl);
-            // 2. 만료 시간 관리를 위해 active_sessions에 추가
+
+            // 2. 만료 시간 관리를 위해 active_sessions Sorted Set에 추가 (Score: 만료시간, Value: userId)
             batch.getScoredSortedSet(activeSessionsKey, LongCodec.INSTANCE).addAsync(expiryTimestamp, userId);
 
             // 3. 알림이 필요한 경우 (스케줄러에 의해 호출될 때) 알림 전송
@@ -83,17 +99,37 @@ public class AdmissionService {
         // 4. 활성 사용자 수 원자적으로 증가
         batch.getAtomicLong(activeUserCountKey).addAndGetAsync(userIds.size());
 
-        // 배치 작업 실행
+        // 5. 준비된 모든 명령을 Redis 서버로 한 번에 전송
         try {
             batch.execute();
             log.info("{}명 입장 처리 배치 작업 성공. 현재 총 활성 사용자 수: {}",
                     userIds.size(), redissonClient.getAtomicLong(activeUserCountKey).get());
         } catch (Exception e) {
             log.error("[BATCH_EXECUTE_FAILED] 사용자 ID 리스트 {} 입장 처리 중 배치 실행 실패", userIds, e);
-            throw new BusinessException(ErrorCode.REDIS_COMMAND_FAILED, "입장 처리 중 시스템 오류가 발생했습니다.");
+            throw new BusinessException(ErrorCode.REDIS_COMMAND_FAILED, "입장 처리 중 시스템 오류가 발생");
         }
 
-        log.debug("{}명 입장 처리 완료. 현재 총 활성 사용자 수: {}", userIds.size(), redissonClient.getAtomicLong(activeUserCountKey).get());
         return issuedKeys;
+    }
+
+    /**
+     * 즉시 입장을 위해 슬롯이 남아있는지 확인하고 원자적으로 점유를 시도
+     * 'Compare-And-Set' (CAS) 연산을 사용하여 여러 스레드가 동시에 접근해도 경쟁 상태(Race Condition)를 방지
+     *
+     * @param concertId 점유를 시도할 콘서트 ID
+     * @return 슬롯 점유에 성공하면 true, 실패하면 false
+     */
+    public boolean tryClaimSlot(Long concertId) {
+        RAtomicLong activeUsersCount = queueRedisAdapter.getActiveUserCounter(concertId);
+
+        while (true) {
+            long current = activeUsersCount.get();
+            if (current >= maxActiveUsers) {
+                return false; // 슬롯 점유 실패
+            }
+            if (activeUsersCount.compareAndSet(current, current + 1)) {
+                return true; // 슬롯 점유 성공!
+            }
+        }
     }
 }

--- a/src/main/java/com/team03/ticketmon/queue/service/NotificationService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/NotificationService.java
@@ -2,12 +2,11 @@ package com.team03.ticketmon.queue.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team03.ticketmon._global.util.RedisKeyGenerator;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import com.team03.ticketmon.queue.dto.AdmissionEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RTopic;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 /**
@@ -19,9 +18,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final RedissonClient redissonClient;
     private final ObjectMapper objectMapper;
-    private static final String ADMISSION_TOPIC = RedisKeyGenerator.ADMISSION_TOPIC;
+    private final QueueRedisAdapter queueRedisAdapter;
 
     /**
      * 특정 사용자에게 발급된 입장 허가 키를 담아 알림 이벤트를 발행.
@@ -35,19 +33,18 @@ public class NotificationService {
             // 1. 이벤트 객체를 JSON 문자열로 직렬화
             String message = objectMapper.writeValueAsString(event);
 
-            log.debug("입장 알림 발행 준비. 채널: {}, 메시지: {}", ADMISSION_TOPIC, message);
+            log.debug("입장 알림 발행 준비. 메시지: {}", message);
 
             // 2. Redis의 특정 토픽(채널)을 가져옴
-            RTopic topic = redissonClient.getTopic(ADMISSION_TOPIC);
+            RTopic topic = queueRedisAdapter.getAdmissionTopic();
 
             // 3. 해당 토픽을 구독(Subscribe)하고 있는 모든 클라이언트에게 메시지를 발행
             long receivers = topic.publish(message);
 
             // 애플리케이션의 중요 상태 변경이므로 INFO 레벨로 기록
-            log.debug("입장 알림 발행 완료. 사용자: {}, 채널: {}, 수신자 수: {}", userId, ADMISSION_TOPIC, receivers);
+            log.debug("입장 알림 발행 완료. 사용자: {}, 수신자 수: {}", userId, receivers);
         } catch (JsonProcessingException e) {
-            // 객체 직렬화는 프로그램 로직 오류일 가능성이 높으므로 ERROR 레벨로 기록
-            log.error("AdmissionEvent 객체 JSON 직렬화 실패! userId: {}", userId, e);
+            log.error("AdmissionEvent JSON 직렬화 실패! userId: {}", userId, e);
         }
     }
 }

--- a/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
@@ -28,9 +28,6 @@ public class WaitingQueueService {
     private final AdmissionService admissionService;
     private final QueueRedisAdapter queueRedisAdapter;
 
-    @Value("${app.queue.max-active-users}")
-    private long maxActiveUsers; // 시스템이 동시에 수용 가능한 최대 활성 사용자 수
-
     /**
      * 특정 콘서트의 대기열에 사용자를 추가하고, 현재 대기 순번을 반환
      * 타임스탬프와 원자적 시퀀스를 조합한 유니크한 점수를 사용해 공정성을 보장
@@ -97,7 +94,7 @@ public class WaitingQueueService {
         String accessKey = accessKeyBucket.get();
 
         if (accessKey != null) {
-            return new QueueStatusDto("ADMITTED", null, accessKey, "입장이 허가된 상태입니다.");
+            return QueueStatusDto.admitted(accessKey);
         }
 
         // 2. 대기열에 있는지 확인
@@ -105,11 +102,11 @@ public class WaitingQueueService {
         Integer rank = queue.rank(userId);
 
         if (rank != null) {
-            return new QueueStatusDto("WAITING", rank.longValue() + 1, null, "현재 대기 중입니다.");
+            return QueueStatusDto.waiting(rank.longValue() + 1);
         }
 
         // 3. 둘 다 해당 없으면 에러 또는 이탈 상태 반환
-        return new QueueStatusDto("EXPIRED_OR_NOT_IN_QUEUE", null, null, "대기열에 정보가 없거나 만료되었습니다.");
+        return QueueStatusDto.expiredOrNotInQueue();
     }
 
 }

--- a/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/WaitingQueueService.java
@@ -2,7 +2,6 @@ package com.team03.ticketmon.queue.service;
 
 import com.team03.ticketmon._global.exception.BusinessException;
 import com.team03.ticketmon._global.exception.ErrorCode;
-import com.team03.ticketmon.concert.service.ConcertService;
 import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import com.team03.ticketmon.queue.dto.QueueStatusDto;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +16,8 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Redis Sorted Set을 이용해 콘서트 대기열을 관리하는 서비스입니다.
- * 이 서비스는 대기열 추가, 순위 조회, 사용자 추출 등의 핵심 기능을 담당하며,
+ * Redis Sorted Set을 이용해 콘서트 대기열을 관리하는 서비스
+ * 이 서비스는 대기열 추가, 순위 조회, 사용자 추출 등의 핵심 기능을 담당
  * 모든 연산은 원자성(Atomic)을 보장해야 합니다.
  */
 @Slf4j
@@ -26,7 +25,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WaitingQueueService {
 
-    private final ConcertService concertService;
     private final AdmissionService admissionService;
     private final QueueRedisAdapter queueRedisAdapter;
 
@@ -42,20 +40,16 @@ public class WaitingQueueService {
      * @return 1부터 시작하는 사용자의 대기 순번
      */
     public QueueStatusDto apply(Long concertId, Long userId) {
-        // 1. 현재 활성 사용자 수를 확인하여 즉시 입장을 시도할지 결정
-        long currentActiveUsers = queueRedisAdapter.getActiveUserCounter(concertId).get();
 
-        // 2. 자리가 남아있다고 판단되면, '원자적 슬롯 점유'를 시도
-        if (currentActiveUsers < maxActiveUsers) {
-            if (admissionService.tryClaimSlot(concertId)) {
-                log.debug("[userId: {}] 즉시 입장 처리 시작.", userId);
-                // 2-1. 슬롯 점유에 성공! -> 즉시 입장 처리
-                String accessKey = admissionService.grantAccess(concertId, userId);
-                return QueueStatusDto.immediateEntry(accessKey);
-            }
+        // 1. 원자적 슬롯 점유 시도
+        if (admissionService.tryClaimSlot(concertId)) {
+            log.debug("[userId: {}] 즉시 입장 처리 시작.", userId);
+            String accessKey = admissionService.grantAccess(concertId, userId);
+            return QueueStatusDto.immediateEntry(accessKey);
         }
 
-        // 3. 슬롯이 꽉 찼거나, 점유 시도에 실패(경쟁에서 밀림)하면 대기열로 진입
+        // 2. 슬롯이 꽉 찼거나, 점유 시도에 실패(경쟁에서 밀림)하면 대기열로 진입
+        log.debug("사용자 {} 대기열 진입 처리 시작.", userId);
         RScoredSortedSet<Long> queue = queueRedisAdapter.getQueue(concertId);
         long uniqueScore = queueRedisAdapter.generateQueueScore(concertId);
 

--- a/src/main/java/com/team03/ticketmon/queue/strategy/NotificationStrategy.java
+++ b/src/main/java/com/team03/ticketmon/queue/strategy/NotificationStrategy.java
@@ -1,0 +1,18 @@
+package com.team03.ticketmon.queue.strategy;
+
+import org.redisson.api.RScoredSortedSet;
+
+/**
+ * 대기열 사용자에게 알림을 보내는 전략에 대한 공통 인터페이스
+ * 이 인터페이스를 구현하여 다양한 알림 정책(예: 개인 순위 알림, 전체 현황 브로드캐스팅) 추가 가능
+ */
+public interface NotificationStrategy {
+
+    /**
+     * 특정 전략에 따라 알림을 전송합니다.
+     *
+     * @param concertId 알림 대상 콘서트 ID
+     * @param queue 현재 대기열 상태를 담고 있는 RScoredSortedSet. 이 객체를 통해 필요한 정보를 조회합니다.
+     */
+    void execute(Long concertId, RScoredSortedSet<Long> queue);
+}

--- a/src/main/java/com/team03/ticketmon/queue/strategy/PersonalizedRankStrategy.java
+++ b/src/main/java/com/team03/ticketmon/queue/strategy/PersonalizedRankStrategy.java
@@ -1,0 +1,45 @@
+package com.team03.ticketmon.queue.strategy;
+
+import com.team03.ticketmon.queue.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.client.protocol.ScoredEntry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PersonalizedRankStrategy implements NotificationStrategy {
+
+    private final NotificationService notificationService;
+
+    @Value("${app.queue.top-ranker-count}")
+    private int topRankerCount;
+
+    @Override
+    public void execute(Long concertId, RScoredSortedSet<Long> queue) {
+        if (queue == null || queue.isEmpty() || topRankerCount <= 0) {
+            return;
+        }
+
+        // 1. 대기열의 최상위 N명의 ID와 점수를 조회합니다.
+        Collection<ScoredEntry<Long>> topRankers = queue.entryRange(0, topRankerCount - 1);
+        if (topRankers == null || topRankers.isEmpty()) {
+            return;
+        }
+
+        log.debug("[Notification] 콘서트 ID {}: 최상위 {}명에게 개인 순위 알림 전송 시작.", concertId, topRankers.size());
+
+        // 2. 각 사용자에게 개인화된 순위 정보를 1:1 메시지로 전송합니다.
+        int rank = 1;
+        for (ScoredEntry<Long> entry : topRankers) {
+            Long userId = entry.getValue();
+
+            // NotificationService에 개별 순위 전송을 위한 새 메서드 호출
+            notificationService.sendRankUpdate(userId, rank++);
+        }
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/strategy/PersonalizedRankStrategy.java
+++ b/src/main/java/com/team03/ticketmon/queue/strategy/PersonalizedRankStrategy.java
@@ -38,8 +38,13 @@ public class PersonalizedRankStrategy implements NotificationStrategy {
         for (ScoredEntry<Long> entry : topRankers) {
             Long userId = entry.getValue();
 
-            // NotificationService에 개별 순위 전송을 위한 새 메서드 호출
-            notificationService.sendRankUpdate(userId, rank++);
+            try {
+                // NotificationService에 개별 순위 전송을 위한 새 메서드 호출
+                notificationService.sendRankUpdate(userId, rank);
+            } catch (Exception e) {
+                log.error("[Notification] 사용자 {}에게 순위 알림 전송 실패: {}", userId, e.getMessage());
+            }
+            rank++;
         }
     }
 }

--- a/src/main/java/com/team03/ticketmon/websocket/MessageType.java
+++ b/src/main/java/com/team03/ticketmon/websocket/MessageType.java
@@ -1,0 +1,9 @@
+package com.team03.ticketmon.websocket;
+
+public enum MessageType {
+    // 서버 -> 클라이언트
+    ADMIT,                  // 입장 허가
+    RANK_UPDATE,            // 실시간 순위 업데이트
+    REDIRECT_TO_RESERVE,    // 예매 페이지로 리디렉션 (재연결 시)
+    ERROR;                  // 에러 알림
+}

--- a/src/main/java/com/team03/ticketmon/websocket/WebSocketPayloadKeys.java
+++ b/src/main/java/com/team03/ticketmon/websocket/WebSocketPayloadKeys.java
@@ -1,0 +1,15 @@
+package com.team03.ticketmon.websocket;
+
+/**
+ * WebSocket 메시지 페이로드에 사용되는 키(key)들을 상수로 관리하는 클래스입니다.
+ * 매직 스트링을 방지하고 코드의 일관성과 안정성을 높입니다.
+ */
+public final class WebSocketPayloadKeys {
+
+    // 인스턴스화 방지
+    private WebSocketPayloadKeys() {}
+
+    public static final String TYPE = "type";
+    public static final String RANK = "rank";
+    public static final String ACCESS_KEY = "accessKey";
+}

--- a/src/main/java/com/team03/ticketmon/websocket/handler/CustomWebSocketHandler.java
+++ b/src/main/java/com/team03/ticketmon/websocket/handler/CustomWebSocketHandler.java
@@ -1,6 +1,8 @@
 package com.team03.ticketmon.websocket.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team03.ticketmon.queue.dto.QueueStatusDto;
+import com.team03.ticketmon.queue.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -21,6 +23,7 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
     // 동시성 이슈를 방지 목적, 스레드에 안전한 콜렉션 사용
     private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper;
+    private final WaitingQueueService waitingQueueService; //  <-- 이 줄을 추가합니다.
 
     /**
      * 클라이언트와 WebSocket 연결이 성공적으로 맺어졌을 때 호출
@@ -30,12 +33,24 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         Long userId = extractUserId(session);
-        if (userId != null) {
+        Long concertId = extractConcertId(session);
+
+
+        if (userId != null && concertId != null) {
+            QueueStatusDto userStatus = waitingQueueService.getUserStatus(concertId, userId);
+
+            if ("ADMITTED".equals(userStatus.status())) {
+                log.info("[WebSocket] 이미 입장한 사용자(ID: {})의 재연결 시도. 예매 페이지로 리디렉션 유도.", userId);
+                session.sendMessage(new TextMessage("{\"type\":\"REDIRECT_TO_RESERVE\", \"accessKey\":\"" + userStatus.accessKey() + "\"}"));
+                session.close(CloseStatus.NORMAL.withReason("Already admitted"));
+                return;
+            }
+
             addSession(userId, session);
             log.debug("WebSocket 연결됨. 사용자: {}, 세션 ID: {}", userId, session.getId());
         } else {
-            // WARN 레벨: 비정상적인 접근 시도일 수 있으므로 경고 로그
-            log.warn("사용자 ID 없이 WebSocket 연결 시도됨. 세션 ID: {}, URI: {}", session.getId(), session.getUri());
+            log.warn("사용자 ID 또는 콘서트 ID 없이 WebSocket 연결 시도됨. 세션 ID: {}, URI: {}", session.getId(), session.getUri());
+            session.close(CloseStatus.POLICY_VIOLATION.withReason("User or Concert ID not found"));
         }
     }
 
@@ -102,6 +117,18 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
         Map<String, Object> attributes = session.getAttributes();
         return (Long) attributes.get("userId");
     }
+
+    /**
+     * 콘서트 ID를 추출
+     *
+     * @param session 클라이언트 세션
+     * @return 추출된 콘서트 ID, 없으면 null
+     */
+    private Long extractConcertId(WebSocketSession session) {
+        Map<String, Object> attributes = session.getAttributes();
+        return (Long) attributes.get("concertId");
+    }
+
 
     // 테스트와 외부에서 세션을 추가하기 위한 public 메서드
     public void addSession(Long userId, WebSocketSession newSession) {

--- a/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
+++ b/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import com.team03.ticketmon.queue.dto.AdmissionEvent;
 import com.team03.ticketmon.queue.dto.RankUpdateEvent;
+import com.team03.ticketmon.websocket.MessageType;
+import com.team03.ticketmon.websocket.WebSocketPayloadKeys;
 import com.team03.ticketmon.websocket.handler.CustomWebSocketHandler;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -53,8 +55,8 @@ public class RedisMessageSubscriber {
 
                 // 2. WebSocket 핸들러를 통해 해당 사용자에게 전송할 메시지(Payload)를 구성
                 Map<String, Object> payload = Map.of(
-                        "type", "ADMIT",
-                        "accessKey", event.accessKey()
+                        WebSocketPayloadKeys.TYPE, MessageType.ADMIT.name(),
+                        WebSocketPayloadKeys.ACCESS_KEY, event.accessKey()
                 );
 
                 // 3. 구성된 메시지를 실제 클라이언트에게 전송
@@ -83,8 +85,8 @@ public class RedisMessageSubscriber {
 
                 // 2. WebSocket 핸들러를 통해 메시지 전송
                 Map<String, Object> payload = Map.of(
-                        "type", "RANK_UPDATE",
-                        "rank", event.rank()
+                        WebSocketPayloadKeys.TYPE, MessageType.RANK_UPDATE.name(),
+                        WebSocketPayloadKeys.RANK, event.rank()
                 );
                 webSocketHandler.sendMessageToUser(event.userId(), payload);
 

--- a/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
+++ b/src/main/java/com/team03/ticketmon/websocket/subscriber/RedisMessageSubscriber.java
@@ -1,14 +1,13 @@
 package com.team03.ticketmon.websocket.subscriber;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team03.ticketmon._global.util.RedisKeyGenerator;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
 import com.team03.ticketmon.queue.dto.AdmissionEvent;
 import com.team03.ticketmon.websocket.handler.CustomWebSocketHandler;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RTopic;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -23,25 +22,31 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class RedisMessageSubscriber {
 
-    private final RedissonClient redissonClient;
     private final ObjectMapper objectMapper;
     private final CustomWebSocketHandler webSocketHandler;
-    private static final String ADMISSION_TOPIC = RedisKeyGenerator.ADMISSION_TOPIC;
+    private final QueueRedisAdapter queueRedisAdapter;
 
     /**
      * 빈(Bean)이 생성되고 의존성 주입이 완료된 후, 자동으로 Redis 토픽 구독을 시작
      */
-    @PostConstruct // 빈이 생성된 후 자동으로 이 메서드를 실행
-    public void subscribeToAdmissionTopic() {
-        RTopic topic = redissonClient.getTopic(ADMISSION_TOPIC);
+    @PostConstruct
+    public void subscribeToTopics() {
+        // 입장 알림 구독
+        subscribeToAdmissionTopic();
+    }
 
-        // 메시지를 수신했을 때 실행될 리스너를 등록.
+    /**
+     * 입장 알림 토픽을 구독
+     */
+    private void subscribeToAdmissionTopic() {
+        RTopic topic = queueRedisAdapter.getAdmissionTopic();
+
         topic.addListener(CharSequence.class, (channel, msg) -> {
-            log.debug("Redis 채널에서 메시지 수신. 채널: {}, 원본 메시지: {}", channel, msg);
+            log.debug("[입장 알림] Redis 채널에서 메시지 수신. 채널: {}, 원본 메시지: {}", channel, msg);
             try {
                 // 1. 수신된 JSON 메시지를 AdmissionEvent 객체로 역직렬화
                 AdmissionEvent event = objectMapper.readValue(msg.toString(), AdmissionEvent.class);
-                log.debug("입장 알림 이벤트 수신 완료. 사용자: {}", event.userId());
+                log.debug("[입장 알림] 이벤트 수신 완료. 사용자: {}", event.userId());
 
                 // 2. WebSocket 핸들러를 통해 해당 사용자에게 전송할 메시지(Payload)를 구성
                 Map<String, Object> payload = Map.of(
@@ -54,10 +59,9 @@ public class RedisMessageSubscriber {
 
             } catch (IOException e) {
                 // 메시지 파싱 또는 처리 실패는 데이터 형식 문제일 수 있으므로 ERROR 레벨로 기록
-                log.error("수신된 Redis 메시지 처리 중 오류 발생!", e);
+                log.error("[입장 알림] 수신된 Redis 메시지 처리 중 오류 발생!", e);
             }
         });
-
-        log.info("Redis Pub/Sub 구독 시작. 채널: '{}'", ADMISSION_TOPIC);
+        log.info("[입장 알림] Redis Pub/Sub 구독 시작.");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 app:
   queue:
-    max-active-users: 5 # 예매 페이지에 동시 진입 가능한 최대 사용자 수
+    max-active-users: 1 # 예매 페이지에 동시 진입 가능한 최대 사용자 수
     access-key-ttl-minutes: 1 # 예매 페이지 접근 키의 유효시간 (단위: 분)
-    top-ranker-count: 1000 #  최상위 대기자 기준 설정
+    top-ranker-count: 1 #  최상위 대기자 기준 설정
 
   # ✅ 새로 추가: 스케줄러 관련 설정 - [좌석 관리 및 예매 모듈]
   scheduler:


### PR DESCRIPTION
## 1. [기능명] 구현/수정

### 대기열 시스템 아키텍처 개선 및 실시간 상호작용 기능 강화

## 2. 작업 내용

이번 PR은 대기열 시스템의 내부 구조를 개선하여 **유지보수성과 안정성**을 높이고, 사용자에게 **실시간 피드백**을 제공하여 대기 경험을 향상시키는 것을 목표로 합니다.

-   **Redis 데이터 접근 계층 추상화 및 중앙화 (`QueueRedisAdapter` 도입)**:
    -   **문제점**: 기존에는 `Scheduler`, `Service`, `Filter` 등 여러 컴포넌트가 `RedissonClient`를 직접 사용하여 Redis에 접근했습니다. 이로 인해 Redis의 키 구조나 데이터 타입 같은 내부 구현이 외부에 노출되고, 관련 로직이 여러 곳에 중복되어 유지보수가 어려웠습니다.
    -   **해결**: **`QueueRedisAdapter`** 를 도입하여 대기열 도메인과 관련된 모든 Redis 데이터 접근 로직을 중앙에서 관리하도록 캡슐화했습니다. 이제 다른 서비스들은 Redis의 구체적인 구현을 몰라도, Adapter가 제공하는 고수준 메서드를 통해 일관된 방식으로 데이터에 접근합니다.
    -   **영향**: **단일 책임 원칙(SRP)** 을 준수하게 되어 코드의 응집도가 높아졌고, 향후 Redis 관련 정책 변경 시 Adapter만 수정하면 되므로 유지보수성이 극대화되었습니다.

-   **'즉시 입장' 경쟁 상태(Race Condition) 해결**:
    -   **문제점**: '즉시 입장' 가능 여부를 판단하는 "조회 후 실행(Check-then-act)" 로직은, 여러 사용자가 동시에 진입을 시도할 경우 설정된 최대 활성 사용자 수를 초과할 수 있는 경쟁 상태에 취약했습니다.
    -   **해결**: Redis의 `compareAndSet`(CAS) 연산을 활용한 **원자적 슬롯 점유 시도(`tryClaimSlot`)** 기능을 구현했습니다. 이를 통해 여러 요청이 동시에 들어와도 오직 하나의 요청만이 성공적으로 슬롯을 차지하도록 보장합니다.
    -   **영향**: 시스템 입구의 데이터 정합성을 보장하여, 동시성으로 인해 발생할 수 있는 심각한 버그를 원천 차단하고 공정성을 확보했습니다.

-   **실시간 대기 순위 알림 기능 구현**:
    -   **문제점**: 사용자는 대기 중 자신의 순위 변화를 알 수 없어, 서비스가 정상 동작하는지 몰라 불안감을 느끼고 이탈할 가능성이 높았습니다.
    -   **해결**: 웹소켓과 Redis Pub/Sub을 이용하여, 스케줄러가 주기적으로 최상위 대기자들에게 **개인의 현재 순위를 실시간으로 전송**하는 기능을 구현했습니다. 향후 다양한 알림 정책(전체 공지 등)을 유연하게 추가할 수 있도록 **전략 패턴(Strategy Pattern)** 을 적용하여 확장성을 확보했습니다.
    -   **영향**: 사용자에게 진행 상황에 대한 명확한 피드백을 제공하여, 대기 경험의 질을 크게 향상시키고 서비스에 대한 신뢰도를 높입니다.

---

## 3. 주요 변경사항

✨ **새로 추가된 파일:**
-   `src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java`: Redis 데이터 접근을 전담하는 어댑터 클래스
-   `src/main/java/com/team03/ticketmon/queue/strategy/NotificationStrategy.java`: 알림 전략 인터페이스
-   `src/main/java/com/team03/ticketmon/queue/strategy/PersonalizedRankStrategy.java`: 개인 순위 알림 전략 구현체
-   `src/main/java/com/team03/ticketmon/queue/dto/RankUpdateEvent.java`: 순위 업데이트 이벤트 DTO

🔧 **수정된 파일:**
-   `queue/service/WaitingQueueService.java`: `QueueRedisAdapter`를 사용하도록 리팩토링 및 `tryClaimSlot` 연동 로직 추가
-   `queue/service/AdmissionService.java`: `tryClaimSlot` 메서드 추가
-   `queue/service/NotificationService.java`: `sendRankUpdate` 메서드 추가 (Redis Pub/Sub 발행)
-   `queue/scheduler/WaitingQueueScheduler.java`: 알림 전략 실행 로직 추가
-   `queue/scheduler/CleanupScheduler.java`: `QueueRedisAdapter`를 사용하도록 리팩토링
-   `queue/scheduler/ConsistencyCheckScheduler.java`: `QueueRedisAdapter`를 사용하도록 리팩토링
-   `websocket/subscriber/RedisMessageSubscriber.java`: 순위 업데이트 토픽 구독 로직 추가
-   `auth/jwt/AccessKeyFilter.java`: `QueueRedisAdapter`를 사용하도록 리팩토링

---

## 4. 리뷰어를 위한 테스트 가이드

-   **[핵심 테스트 1] 실시간 순위 알림 확인**:
    -   브라우저 2개 이상을 열어 동일한 콘서트의 대기열에 순서대로 진입합니다.
    -   **[기대 결과]** 브라우저 개발자 도구의 Network 탭(WS)에서, 스케줄러 실행 주기마다 `{"type":"RANK_UPDATE", "rank":1}` 과 같은 웹소켓 메시지가 수신되는지 확인합니다. 백엔드 로그에서도 관련 알림 로그가 출력되는지 확인합니다.

-   **[핵심 테스트 2] 첫 번째 진입자 정상 처리 확인**:
    -   활성 사용자가 0명인 상태에서, 첫 번째 사용자가 '예매하기'를 눌러 즉시 입장이 되는지 확인합니다. (이를 위해 `WaitingQueueService.apply`의 분기 로직이 정상 동작해야 합니다.)
    -   **[기대 결과]** 대기열을 거치지 않고, `IMMEDIATE_ENTRY` 응답과 함께 즉시 예매 페이지로 진입해야 합니다.

---

## 5. 관련 이슈
-   N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자별 실시간 대기 순위 알림 기능이 추가되었습니다.
  * 대기열 입장 시 동시 접속 허용 인원 제한 및 즉시 입장 처리 기능이 도입되었습니다.
  * WebSocket 연결 시 대기 상태에 따라 자동 페이지 이동 또는 안내 메시지가 제공됩니다.

* **개선 및 변경**
  * 대기열 관련 Redis 연동이 `QueueRedisAdapter`로 일원화되어 성능과 안정성이 향상되었습니다.
  * 대기열, 입장, 알림 관련 서비스의 동시성 제어 및 오류 처리가 강화되었습니다.
  * 대기열 점수 생성, 알림 전략, 메시지 구독 등이 구조적으로 개선되고 확장성이 높아졌습니다.
  * WebSocket 인증 시 `concertId` 검증이 추가되고, 로그 메시지가 한글화되었습니다.

* **설정**
  * 동시 입장 가능 인원 및 상위 대기자 수가 1명으로 변경되었습니다.

* **버그 수정**
  * 중복 대기열 등록 및 순위 계산 오류가 방지되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->