### PR TITLE
[FIX] JWT 인증 필터 예외 처리 및 로그아웃 로직 개선

### DIFF
--- a/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
+++ b/src/main/java/com/team03/ticketmon/auth/Util/CookieUtil.java
@@ -39,8 +39,7 @@ public class CookieUtil {
     }
 
     // Access Token과 Refresh Token 쿠키 삭제 (로그아웃)
-    public void deleteJwtCookies(Long userId, HttpServletResponse response) {
-        refreshTokenService.deleteRefreshToken(userId);
+    public void deleteJwtCookies(HttpServletResponse response) {
         ResponseCookie accessCookie = deleteCookie(jwtTokenProvider.CATEGORY_ACCESS);
         ResponseCookie refreshCookie = deleteCookie(jwtTokenProvider.CATEGORY_REFRESH);
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/CustomLogoutFilter.java
@@ -41,15 +41,16 @@ public class CustomLogoutFilter extends GenericFilterBean {
         }
 
         try {
-            Long userId = jwtTokenProvider.getUserId(refreshToken);
-
             refreshTokenService.validateRefreshToken(refreshToken, true);
 
-            cookieUtil.deleteJwtCookies(userId, response);
+            Long userId = jwtTokenProvider.getUserId(refreshToken);
 
+            refreshTokenService.deleteRefreshToken(userId);
             response.setStatus(HttpServletResponse.SC_OK);
         } catch (Exception e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } finally {
+            cookieUtil.deleteJwtCookies(response);
         }
     }
 

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (isEmpty(refreshToken)) {
             if (!isEmpty(accessToken)) {
-                // Access Token이 쿠키에 남아있으면 삭제
+                // Refresh Token이 없고 Access Token만 남아 있으면 삭제
                 ResponseCookie accessCookie = cookieUtil.deleteCookie(jwtTokenProvider.CATEGORY_ACCESS);
                 response.addHeader("Set-Cookie", accessCookie.toString());
             }
@@ -38,39 +38,48 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 만료 여부 확인 및 재발급
+        // Access Token이 유효하다면 그대로 인증 처리
         if (!isEmpty(accessToken) && !jwtTokenProvider.isTokenExpired(accessToken)) {
             setAuthenticationContext(accessToken);
             filterChain.doFilter(request, response);
             return;
         }
 
+        // Access Token이 만료되었고 Refresh Token 유효성 확인 후 재발급
         accessToken = handleTokenReissue(refreshToken, response);
 
-        if (isEmpty(accessToken))
-            return;
+        if (isEmpty(accessToken)) return;
 
-        if (!isAccessToken(accessToken, response))
-            return;
+        if (!isAccessToken(accessToken, response)) return;
 
         setAuthenticationContext(accessToken);
         filterChain.doFilter(request, response);
     }
 
     private String handleTokenReissue(String refreshToken, HttpServletResponse response) throws IOException {
-
-        // Access Token이 만료되었고 Refresh Token 유효성 확인 후 재발급
         log.info("Access Token 만료됨 Refresh Token으로 재발급 시도");
-        String newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, true);
-        if (isEmpty(newAccessToken)) {
-            log.warn("Refresh Token이 유효하지 않음 재로그인 필요");
+
+        String newAccessToken = null;
+        try {
+            newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, true);
+
+            if (isEmpty(newAccessToken)) {
+                log.warn("Refresh Token이 유효하지 않음 재로그인 필요");
+                cookieUtil.deleteJwtCookies(response);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 만료되었거나 유효하지 않습니다.");
+                return null;
+            }
+
+            Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
+            ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
+            response.addHeader("Set-Cookie", accessCookie.toString());
+
+        } catch (IllegalArgumentException e) {
+            log.warn("Access Token 재발급 실패: {}", e.getMessage());
+            cookieUtil.deleteJwtCookies(response);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 만료되었거나 유효하지 않습니다.");
             return null;
         }
-
-        Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
-        ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
-        response.addHeader("Set-Cookie", accessCookie.toString());
         return newAccessToken;
     }
 
@@ -80,6 +89,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return jwtTokenProvider.CATEGORY_ACCESS.equals(category);
         } catch (Exception e) {
             log.error("Access Token 파싱 실패 : {}", e.getMessage());
+            cookieUtil.deleteJwtCookies(response);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access Token 파싱에 실패했습니다.");
             return false;
         }

--- a/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/team03/ticketmon/auth/jwt/JwtAuthenticationFilter.java
@@ -59,9 +59,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String handleTokenReissue(String refreshToken, HttpServletResponse response) throws IOException {
         log.info("Access Token 만료됨 Refresh Token으로 재발급 시도");
 
-        String newAccessToken = null;
         try {
-            newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, true);
+            String newAccessToken = reissueService.reissueToken(refreshToken, jwtTokenProvider.CATEGORY_ACCESS, true);
 
             if (isEmpty(newAccessToken)) {
                 log.warn("Refresh Token이 유효하지 않음 재로그인 필요");
@@ -73,14 +72,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Long accessExp = jwtTokenProvider.getExpirationMs(jwtTokenProvider.CATEGORY_ACCESS);
             ResponseCookie accessCookie = cookieUtil.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccessToken, accessExp);
             response.addHeader("Set-Cookie", accessCookie.toString());
+            return newAccessToken;
 
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             log.warn("Access Token 재발급 실패: {}", e.getMessage());
             cookieUtil.deleteJwtCookies(response);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 만료되었거나 유효하지 않습니다.");
             return null;
         }
-        return newAccessToken;
     }
 
     private boolean isAccessToken(String token, HttpServletResponse response) throws IOException {


### PR DESCRIPTION
# 🔐 [인증] JWT 인증 필터 예외 처리 및 로그아웃 로직 개선

## 작업 내용

* [x] JWT 인증 필터 예외 처리 강화
* [x] 토큰 재발급 실패 시 쿠키 정리 로직 개선
* [x] 로그아웃 시 쿠키 삭제 로직 최적화
* [x] 에러 응답 표준화 및 로깅 개선
* [x] 토큰 파싱 실패 시 안전한 쿠키 정리

## 주요 변경사항

### **새로 추가된 파일**:
- 없음

### **수정된 파일**:
- `CookieUtil.java`: 쿠키 삭제 메서드 파라미터 단순화
- `CustomLogoutFilter.java`: 로그아웃 로직 개선 및 finally 블록 추가
- `JwtAuthenticationFilter.java`: 토큰 재발급 예외 처리 강화

### **삭제된 파일**:
- 없음

## 기술적 변경사항

### 1. 쿠키 삭제 로직 개선
```java
// Before: userId 파라미터가 필요했지만 사용하지 않음
public void deleteJwtCookies(Long userId, HttpServletResponse response) {
    refreshTokenService.deleteRefreshToken(userId);
    // 쿠키 삭제 로직
}

// After: 파라미터 단순화
public void deleteJwtCookies(HttpServletResponse response) {
    // 쿠키 삭제만 담당
}
```

### 2. 로그아웃 로직 안전성 강화
```java
// Before: 예외 발생 시 쿠키가 남아있을 수 있음
try {
    // 로그아웃 로직
    cookieUtil.deleteJwtCookies(userId, response);
} catch (Exception e) {
    // 에러 처리
}

// After: finally 블록으로 안전한 쿠키 정리 보장
try {
    // 로그아웃 로직
    refreshTokenService.deleteRefreshToken(userId);
} catch (Exception e) {
    // 에러 처리
} finally {
    cookieUtil.deleteJwtCookies(response); // 항상 실행
}
```

### 3. 토큰 재발급 예외 처리 강화
```java
// Before: 예외 처리 없이 null 반환
String newAccessToken = reissueService.reissueToken(refreshToken, ...);
if (isEmpty(newAccessToken)) {
    // 에러 처리
}

// After: try-catch로 명시적 예외 처리
try {
    String newAccessToken = reissueService.reissueToken(refreshToken, ...);
    // 성공 처리
} catch (IllegalArgumentException e) {
    log.warn("Access Token 재발급 실패: {}", e.getMessage());
    cookieUtil.deleteJwtCookies(response);
    // 에러 응답
}
```

## 보안 개선사항

### **쿠키 정리 보장**
- 모든 인증 실패 시나리오에서 쿠키가 안전하게 삭제됨
- 토큰 파싱 실패 시에도 쿠키 정리 수행
- 로그아웃 시 예외 발생 여부와 관계없이 쿠키 삭제

### **에러 응답 표준화**
- 모든 인증 실패 시 `401 Unauthorized` 응답
- 명확한 에러 메시지로 클라이언트 디버깅 지원
- 로깅 강화로 서버 사이드 모니터링 개선

## 사용자 경험 개선

### **세션 정리 자동화**
- 토큰 관련 오류 발생 시 자동으로 세션 정리
- 사용자가 수동으로 로그아웃할 필요 없음
- 일관된 인증 상태 유지

### **명확한 에러 피드백**
- 토큰 만료 시 명확한 메시지 제공
- 재로그인 필요 시점 명시
- 클라이언트에서 적절한 리다이렉션 가능

## 보안 확인사항

* [x] 민감정보 환경변수 처리 (토큰 관련 설정값 사용)
* [x] 입력값 validation 어노테이션 적용 (토큰 유효성 검증)
* [x] 에러 핸들링 시 내부 정보 노출 방지 (표준화된 에러 메시지)
* [x] 쿠키 삭제 보장으로 세션 하이재킹 방지
* [x] 토큰 파싱 실패 시 안전한 처리

## 참고사항

- 이 변경사항은 기존 인증 로직과 호환됩니다
- 클라이언트에서 401 응답 시 로그인 페이지로 리다이렉션 구현 권장
- 로그 레벨 설정에 따라 디버깅 정보 조절 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 로그아웃 및 인증 과정에서 토큰 유효성 검사와 예외 처리 로직이 개선되어, 토큰 오류 발생 시 쿠키가 항상 안전하게 삭제됩니다.
  * 토큰 재발급 실패 시 모든 JWT 쿠키가 삭제되고, 인증 오류가 사용자에게 명확히 전달됩니다.

* **리팩터링**
  * 내부 토큰 처리 및 쿠키 삭제 로직이 정리되어, 인증 흐름의 안정성과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->