### PR TITLE
[FIX] 로그인 인증 엔드포인트 개선 및 설정 정리

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -117,7 +117,7 @@ public class SecurityConfig {
 					//------------인증 없이 접근 허용할 경로들 (permitAll())------------
 					// 로그인/회원가입/토큰 갱신 등 인증 관련 API 및 페이지
 					.requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/register").permitAll() // 인증(로그인, 회원가입) 관련 API 경로 허용 (인증 불필요)
-					.requestMatchers("/auth/**").permitAll() // login.html, register.html 등
+					.requestMatchers("/auth/**", "/api/auth/me", "/api/auth/register/social").permitAll() // login.html, register.html 등
 					.requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger UI 및 API 문서
 
 					// 콘서트 정보 조회 (목록, 검색, 필터링, 상세, AI 요약, 리뷰/기대평 목록) - 공개 API

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,7 +45,6 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope:
-              - openid
               - profile
               - email
           naver:


### PR DESCRIPTION
# 🔐 [인증] 

## 작업 내용

* [x] 사용자 인증 정보 조회 API 리팩토링
* [x] 인증 엔드포인트 보안 설정 추가
* [x] 코드 가독성 및 유지보수성 개선
* [x] OAuth2 설정 정리 (불필요한 scope 제거)
* [x] API 문서 오타 수정

## 주요 변경사항

### **새로 추가된 파일**:
- 없음

### **수정된 파일**:
- `SecurityConfig.java`: 인증 API 엔드포인트 보안 설정 추가
- `loginAPIController.java`: 사용자 인증 정보 조회 로직 리팩토링
- `application-prod.yml`: Google OAuth2 설정 정리

### **삭제된 파일**:
- 없음

## 기술적 변경사항

### 1. 보안 설정 개선
```java
// Before: 제한적인 인증 API 허용
.requestMatchers("/auth/**").permitAll()

// After: 추가 인증 API 엔드포인트 허용
.requestMatchers("/auth/**", "/api/auth/me", "/api/auth/register/social").permitAll()
```

### 2. 인증 정보 조회 로직 리팩토링
```java
// Before: 인라인 처리로 복잡한 조건문
public ResponseEntity<?> getCurrentUser(Authentication authentication) {
    if (authentication == null || !authentication.isAuthenticated()) 
        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
    
    if (!(authentication.getPrincipal() instanceof CustomUserDetails userDetails)) {
        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
    }
    // ... 로직 계속
}

// After: 메서드 분리로 가독성 향상
public ResponseEntity<?> getCurrentUser(Authentication authentication) {
    CustomUserDetails userDetails = extractUserDetails(authentication);
    if (userDetails == null) return ResponseEntity.ok().body(null);
    
    // ... 로직 계속
}

private CustomUserDetails extractUserDetails(Authentication authentication) {
    if (authentication == null || !authentication.isAuthenticated()) return null;
    Object principal = authentication.getPrincipal();
    if (principal instanceof CustomUserDetails userDetails) {
        return userDetails;
    }
    return null;
}
```

### 3. OAuth2 설정 정리
```yaml
# Before: 불필요한 openid scope 포함
scope:
  - openid
  - profile
  - email

# After: 필요한 scope만 유지
scope:
  - profile
  - email
```

## 코드 품질 개선

### **가독성 향상**
- 복잡한 조건문을 별도 메서드로 분리
- 메서드명으로 의도를 명확하게 표현
- 네스팅 깊이 감소로 코드 이해도 향상

### **유지보수성 개선**
- 인증 정보 추출 로직 재사용 가능
- 단일 책임 원칙 적용
- 테스트 작성 용이성 향상

### **일관성 개선**
- 인증 실패 시 일관된 응답 처리
- null 체크 로직 표준화
- 에러 처리 방식 통일

## API 동작 변경사항

### **`/api/auth/me` 엔드포인트**
- **Before**: 인증 실패 시 `401 Unauthorized` 응답
- **After**: 인증 실패 시 `200 OK` + `null` body 응답
```

## 보안 확인사항

* [x] 민감정보 환경변수 처리 (OAuth2 클라이언트 정보)
* [x] 입력값 validation 어노테이션 적용 (인증 객체 검증)
* [x] 에러 핸들링 시 내부 정보 노출 방지 (표준화된 응답)
* [x] 인증 엔드포인트 적절한 허용 범위 설정
* [x] OAuth2 scope 최소화로 권한 제한

## 테스트 확인 항목

- [ ] `/api/auth/me` 엔드포인트 로그인 상태에서 정상 응답 확인
- [ ] `/api/auth/me` 엔드포인트 비로그인 상태에서 null 응답 확인
- [ ] `/api/auth/register/social` 엔드포인트 접근 가능 확인
- [ ] Google OAuth2 로그인 정상 동작 확인 (profile, email scope)
- [ ] 기존 인증 흐름 정상 동작 확인
- [ ] Swagger UI에서 API 문서 확인

## 참고사항

- OAuth2 설정 변경으로 Google 인증 권한 요청 범위가 축소됩니다
- 기존 인증 토큰은 영향받지 않습니다
- API 문서의 오타가 수정되었습니다 ("안증" → "인증")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/api/auth/me` 및 `/api/auth/register/social` 엔드포인트에 인증 없이 접근할 수 있도록 허용되었습니다.

* **버그 수정**
  * 로그인 상태 확인 시 인증되지 않은 사용자의 경우 401 오류 대신 200 응답과 null 본문이 반환됩니다.

* **문서화**
  * API 문서의 설명이 수정되고 401 응답 관련 설명이 제거되었습니다.

* **설정**
  * Google OAuth2 클라이언트 등록 시 "openid" 범위가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->