### PR TITLE
[FIX] 소셜 로그인에 따른 페이지 리다이렉트 경로 수정

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
+++ b/src/main/java/com/team03/ticketmon/_global/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
 	private final CookieUtil cookieUtil;
 	private final CorsProperties corsProperties;
 	private final QueueRedisAdapter queueRedisAdapter;
+	private final AppProperties appProperties;
 
 	/**
 	 * <b>AuthenticationManager 빈 설정</b> <br>
@@ -261,7 +262,7 @@ public class SecurityConfig {
 	 */
 	@Bean
 	public OAuth2LoginSuccessHandler oAuth2SuccessHandler() {
-		return new OAuth2LoginSuccessHandler(userEntityService, cookieUtil);
+		return new OAuth2LoginSuccessHandler(appProperties, userEntityService, cookieUtil);
 	}
 
 	/**
@@ -270,7 +271,7 @@ public class SecurityConfig {
 	 */
 	@Bean
 	public OAuth2LoginFailureHandler oAuth2LoginFailureHandler() {
-		return new OAuth2LoginFailureHandler();
+		return new OAuth2LoginFailureHandler(appProperties);
 	}
 
 }

--- a/src/main/java/com/team03/ticketmon/auth/oauth2/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/team03/ticketmon/auth/oauth2/OAuth2LoginFailureHandler.java
@@ -1,9 +1,9 @@
 package com.team03.ticketmon.auth.oauth2;
 
+import com.team03.ticketmon._global.config.AppProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -14,20 +14,21 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
-    @Value("${app.frontend.url:http://localhost:5173}")
-    private String targetUrl;
+    private final AppProperties appProperties;
     private final String REGISTER_URL = "/register";
     private final String LOGIN_URL = "/login";
     private final String NEED_SIGNUP_ERROR_CODE = "need_signup";
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        String frontUrl = appProperties.frontBaseUrl();
+
         if (exception instanceof OAuth2AuthenticationException) {
             OAuth2AuthenticationException ex = (OAuth2AuthenticationException) exception;
 
             if (NEED_SIGNUP_ERROR_CODE.equals(ex.getError().getErrorCode())) {
                 String registerUrl = UriComponentsBuilder
-                        .fromUriString(targetUrl + REGISTER_URL)
+                        .fromUriString(frontUrl + REGISTER_URL)
                         .queryParam("error", NEED_SIGNUP_ERROR_CODE)
                         .build().toUriString();
 
@@ -39,6 +40,6 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
         // 기본 실패 처리
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.sendRedirect(targetUrl + LOGIN_URL);
+        response.sendRedirect(frontUrl + LOGIN_URL);
     }
 }

--- a/src/main/java/com/team03/ticketmon/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/team03/ticketmon/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,15 +1,12 @@
 package com.team03.ticketmon.auth.oauth2;
 
+import com.team03.ticketmon._global.config.AppProperties;
 import com.team03.ticketmon.auth.Util.CookieUtil;
-import com.team03.ticketmon.auth.jwt.JwtTokenProvider;
-import com.team03.ticketmon.auth.service.RefreshTokenService;
 import com.team03.ticketmon.user.domain.entity.UserEntity;
 import com.team03.ticketmon.user.service.UserEntityService;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -21,8 +18,7 @@ import java.util.Collection;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
-    @Value("${app.frontend.url:http://localhost:5173}")
-    private String frontendUrl;
+    private final AppProperties appProperties;
     private final UserEntityService userEntityService;
     private final CookieUtil cookieUtil;
 
@@ -47,6 +43,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         cookieUtil.generateAndSetJwtCookies(userId, username, role, response);
 
+        String frontendUrl = appProperties.frontBaseUrl();
         response.setStatus(HttpServletResponse.SC_OK);
         response.sendRedirect(frontendUrl);
     }


### PR DESCRIPTION
[FIX] 소셜 로그인에 따른 페이지 리다이렉트 경로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * OAuth2 로그인 성공 및 실패 처리 시 프론트엔드 URL을 직접 주입하는 방식 대신 설정 클래스(AppProperties)에서 가져오도록 개선되었습니다.  
  * 내부적으로 설정 관리가 일원화되어 유지보수성이 향상되었습니다.  
  * 사용자 경험 및 기능에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->