### PR TITLE
[FEAT] 액세스키 세션 관리 및 연장 기능 추가

### DIFF
--- a/src/main/java/com/team03/ticketmon/_global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/team03/ticketmon/_global/util/RedisKeyGenerator.java
@@ -34,7 +34,6 @@ public class RedisKeyGenerator {
     private static final String CONCERT_PREFIX = "concert:";
     private static final String USER_PREFIX = "user:";
     public static final String JWT_RT_PREFIX = "refreshToken:";
-    // --- 대기열 관련 키 ---
 
     /** 🔑 `waitqueue:concert:{concertId}`<br>
      * 콘서트별 대기열 정보를 담는 Sorted Set 키입니다.<br>
@@ -42,8 +41,6 @@ public class RedisKeyGenerator {
      * - value: userId
      */
     private static final String WAIT_QUEUE_KEY_PREFIX = "waitqueue:";
-
-    // --- 활성 사용자 관련 키 ---
 
     /** 🔑 `active_sessions:concert:{concertId}`<br>
      * 콘서트별 활성 사용자의 세션 정보를 저장하는 Sorted Set 키입니다.<br>
@@ -57,13 +54,17 @@ public class RedisKeyGenerator {
      */
     private static final String ACTIVE_USERS_COUNT_KEY_PREFIX = "active_users_count:";
 
-    // --- 접근 제어 관련 키 ---
-
     /** 🔑 `accesskey:concert:{concertId}:user:{userId}`<br>
      * 입장 허가(AccessKey)를 저장하는 사용자별 String(Bucket) 키입니다.<br>
      * TTL 기반으로 자동 만료되며, 입장 검증 필터에서 사용됩니다.
      */
     private static final String ACCESS_KEY_PREFIX = "accesskey:";
+
+    /** * 🔑 `final_expiry:concert:{concertId}:user:{userId}`<br>
+     * 세션의 절대적인 최종 만료 시각(timestamp)을 저장하는 키입니다.<br>
+     * 이 키의 값은 연장되지 않으며, 세션의 최대 수명을 제한하는 기준으로 사용됩니다.
+     */
+    private static final String FINAL_EXPIRY_KEY_PREFIX = "final_expiry:";
 
     // --- 스케줄러 락 키 ---
 
@@ -162,4 +163,13 @@ public class RedisKeyGenerator {
         return ACCESS_KEY_PREFIX + CONCERT_PREFIX + concertId + ":" + USER_PREFIX + userId;
     }
 
+    /**
+     * 🎯 사용자별 최종 만료 시각 키 생성
+     * @param concertId 콘서트 ID
+     * @param userId 사용자 ID
+     * @return Redis 키: `final_expiry:concert:{concertId}:user:{userId}`
+     */
+    public String getFinalExpiryKey(Long concertId, Long userId) {
+        return FINAL_EXPIRY_KEY_PREFIX + CONCERT_PREFIX + concertId + ":" + USER_PREFIX + userId;
+    }
 }

--- a/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
+++ b/src/main/java/com/team03/ticketmon/queue/adapter/QueueRedisAdapter.java
@@ -89,6 +89,17 @@ public class QueueRedisAdapter {
         return redissonClient.getBucket(accessKey);
     }
 
+    /**
+     * 사용자의 특정 콘서트의 최종 만료 시각(Bucket) 객체를 반환
+     * @param concertId 조회할 콘서트 ID
+     * @param userId 조회할 사용자 ID
+     * @return 최종 만료 시각(Long)을 담는 RBucket 객체
+     */
+    public RBucket<Long> getFinalExpiryBucket(Long concertId, Long userId) {
+        String finalExpiryKey = keyGenerator.getFinalExpiryKey(concertId, userId);
+        return redissonClient.getBucket(finalExpiryKey);
+    }
+
     public RLock getAdmissionSchedulerLock() {
         String key = RedisKeyGenerator.ADMISSION_SCHEDULER_LOCK_KEY;
         return redissonClient.getLock(key);

--- a/src/main/java/com/team03/ticketmon/queue/controller/AccessKeyController.java
+++ b/src/main/java/com/team03/ticketmon/queue/controller/AccessKeyController.java
@@ -1,0 +1,65 @@
+package com.team03.ticketmon.queue.controller;
+
+import com.team03.ticketmon._global.exception.SuccessResponse;
+import com.team03.ticketmon.auth.jwt.CustomUserDetails;
+import com.team03.ticketmon.queue.service.AccessKeyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * ✅ AccessKeyController
+ * <p>
+ * 사용자의 서비스 접근 키(Access Key)에 대한 만료 시간 연장 및 즉시 폐기 기능을 제공하는 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/access-keys")
+@RequiredArgsConstructor
+public class AccessKeyController {
+
+    private final AccessKeyService accessKeyService;
+
+    /**
+     * <h1>[PATCH /api/access-keys/extend]</h1>
+     * <p>
+     * 특정 콘서트에 대한 사용자의 액세스 키 유효 시간을 연장
+     * </p>
+     * @param concertId 키를 연장할 콘서트의 ID
+     * @param user      Spring Security가 주입해주는 인증된 사용자 정보
+     * @return HTTP 200 OK와 함께 연장된 후의 새로운 유효 시간(초)을 반환
+     */
+    @PatchMapping("/extend")
+    public ResponseEntity<SuccessResponse<Map<String, Long>>> extend(
+            @RequestParam Long concertId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        long newTtl = accessKeyService.extendAccessKey(concertId, user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.of(
+                "액세스 키 유효시간이 연장되었습니다.",
+                Map.of("newTtlSeconds", newTtl)
+        ));
+    }
+
+    /**
+     * <h1>[DELETE /api/access-keys]</h1>
+     * <p>
+     * 특정 콘서트에 대한 사용자의 액세스 키를 즉시 만료(삭제)
+     * </p>
+     * @param concertId 키를 만료시킬 콘서트의 ID
+     * @param user      Spring Security가 주입해주는 인증된 사용자 정보
+     * @return HTTP 200 OK와 함께 성공 메시지를 반환
+     */
+    @DeleteMapping
+    public ResponseEntity<SuccessResponse<Void>> expire(
+            @RequestParam Long concertId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        accessKeyService.invalidateAccessKey(concertId, user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.of("액세스 키가 만료 처리되었습니다.", null));
+    }
+}

--- a/src/main/java/com/team03/ticketmon/queue/service/AccessKeyService.java
+++ b/src/main/java/com/team03/ticketmon/queue/service/AccessKeyService.java
@@ -1,0 +1,80 @@
+package com.team03.ticketmon.queue.service;
+
+import com.team03.ticketmon._global.exception.BusinessException;
+import com.team03.ticketmon._global.exception.ErrorCode;
+import com.team03.ticketmon.queue.adapter.QueueRedisAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RScoredSortedSet;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccessKeyService {
+
+    private final QueueRedisAdapter queueRedisAdapter;
+
+    @Value("${app.queue.access-key-extend-seconds}")
+    private long accessKeyExtendSeconds;
+
+    /**
+     * 액세스 키의 유효 시간을 연장
+     * '최종 만료 시각'을 기준으로 최대 세션 시간을 절대 넘지 않도록 제어
+     *
+     * @param concertId 연장할 콘서트 ID
+     * @param userId    연장할 사용자 ID
+     * @return 새롭게 설정된 유효 시간(초)
+     */
+    public long extendAccessKey(Long concertId, Long userId) {
+        RBucket<String> accessKeyBucket = queueRedisAdapter.getAccessKeyBucket(concertId, userId);
+        RBucket<Long> finalExpiryBucket = queueRedisAdapter.getFinalExpiryBucket(concertId, userId);
+
+        if (!accessKeyBucket.isExists() || !finalExpiryBucket.isExists()) {
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_KEY, "연장할 수 있는 유효한 키가 없습니다.");
+        }
+
+        // 1. 세션의 최종만료시간-현재시간 계산
+        long finalExpiryTimestamp = finalExpiryBucket.get();
+        long remainingLifeSeconds = (finalExpiryTimestamp - System.currentTimeMillis()) / 1000L;
+
+        if (remainingLifeSeconds <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_ACCESS_KEY, "세션이 만료되었습니다.");
+        }
+
+        // 2. 목표 TTL 결정
+        long targetTtlSeconds = Math.min(accessKeyExtendSeconds, remainingLifeSeconds);
+
+        // 3. 현재 키에 실제로 남아있는 TTL 조회
+        long currentTtlSeconds = TimeUnit.MILLISECONDS.toSeconds(accessKeyBucket.remainTimeToLive());
+        long appliedTtl = currentTtlSeconds;
+
+        // 4. 목표 TTL이 현재 남은 TTL보다 클 경우에만 유효 시간을 갱신 (단축 방지)
+        if (appliedTtl > 5000L && targetTtlSeconds > currentTtlSeconds) {
+            accessKeyBucket.expire(Duration.ofSeconds(targetTtlSeconds));
+
+            RScoredSortedSet<Long> activeSessions = queueRedisAdapter.getActiveSessions(concertId);
+            long newScoreTimestamp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(targetTtlSeconds);
+            activeSessions.add(newScoreTimestamp, userId);
+
+            appliedTtl = targetTtlSeconds;
+            log.info("[AccessKey] 키 연장 완료. userId: {}, newTTL: {}초", userId, appliedTtl);
+        }
+
+        return appliedTtl;
+    }
+
+
+    /**
+     * 사용자의 세션을 '만료 예정'으로 표시하여 CleanupScheduler가 처리하도록 위임합니다.
+     */
+    public void invalidateAccessKey(Long concertId, Long userId) {
+        queueRedisAdapter.getActiveSessions(concertId).add(0, userId);
+        log.info("[AccessKey] 키 만료 처리 요청 완료. userId: {}", userId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 app:
   queue:
-    max-active-users: 5 # 예매 페이지에 동시 진입 가능한 최대 사용자 수
-    access-key-ttl-seconds: 300 # 예매 페이지 접근 키의 유효시간 (단위: 초)
-    top-ranker-count: 5 #  최상위 대기자 기준 설정
+    max-active-users: 20 # 예매 페이지에 동시 진입 가능한 최대 사용자 수
+    top-ranker-count: 20 #  최상위 대기자 기준 설정
+    access-key-ttl-seconds: 120
+    access-key-max-ttl-seconds: 480
+    access-key-extend-seconds: 120
   websocket:
     scheduler-health: # WebSocket 연결 현황을 로깅 주기
       delay-ms: 10000


### PR DESCRIPTION
### 📋 주요 변경 사항

* **액세스키 생명주기 관리 기능 구현**
    * 좌석 예매 페이지에 머무는 사용자의 세션이 갑자기 만료되는 것을 방지하기 위해, 액세스키의 유효 시간을 주기적으로 연장하는 기능을 추가했습니다.
    * 이를 통해 좌석을 오래 탐색하는 사용자의 예매 경험을 개선합니다.

* **세션 최대 유효 시간 보장 로직 추가**
    * 세션의 무한 연장을 방지하고 시스템 자원을 보호하기 위해, 최초 입장 시 '최종 만료 시각'을 Redis에 별도로 기록하는 로직을 구현했습니다.
    * 모든 연장 요청은 이 '최종 만료 시각'을 넘지 않는 범위 내에서만 허용됩니다.

* **Lock-Free 연장 로직으로 개선**
    * 기존에 논의되었던 분산 락(Lock) 방식 대신, `extendAccessKey` 메서드에서 조건부 확인을 통해 연산을 처리하는 Lock-Free 방식으로 구현하여 병목 가능성을 제거했습니다.
    * 이를 통해 `CleanupScheduler`와의 경합 없이 안전하고 빠르게 세션을 연장할 수 있습니다.

* **세션 무효화 로직 개선**
    * 사용자 이탈 시 세션을 직접 삭제하는 대신, `CleanupScheduler`가 다음 주기에 정리하도록 표시만 하는 방식으로 변경하여 API 응답 속도를 향상했습니다.

---

### 📂 주요 변경 파일

* **`AccessKeyController.java`**:
    * `[신규]` 세션 연장을 위한 API 엔드포인트(`PATCH /api/access-keys/extend`)를 추가했습니다.

* **`AccessKeyService.java`**:
    * `[신규]` 액세스키 연장 및 무효화 관련 비즈니스 로직을 처리하는 서비스를 작성했습니다.
    * '최종 만료 시각'을 기반으로 연장 가능 여부를 판단하고, 현재 TTL보다 짧아지지 않도록 보장하는 Lock-Free 연장 로직을 구현했습니다.

* **`AdmissionService.java`**:
    * `[수정]` `grantAccess` 메서드에서 최초 키 발급 시, 세션의 '최종 만료 시각'을 함께 Redis에 기록하도록 수정했습니다.

* **`RedisKeyGenerator.java` & `QueueRedisAdapter.java`**:
    * `[수정]` '최종 만료 시각'을 저장하고 조회하기 위한 Redis 키 패턴(`final_expiry:*`)과 관련 접근 메서드를 추가했습니다.

* **`application.yml`**:
    * `[수정]` 액세스키의 최대 허용 시간(`access-key-max-duration-seconds`), 기본 연장 시간(`access-key-extend-seconds`) 등 관련 설정값을 추가했습니다.

---

### ✅ 기대 효과

* 사용자가 좌석을 고르는 동안 세션이 만료되어 이탈하는 부정적인 경험을 방지하여 예매 성공률을 높입니다.
* 분산 락 제거를 통한 예매 페이지의 동시성 처리 성능 향상 및 병목 현상을 완화합니다.
* 명확한 세션 생명주기 관리를 통해 시스템의 안정성 및 예측 가능성을 증대시킵니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 콘서트별 사용자 접근 키의 만료 및 연장 관리 기능이 추가되었습니다.
  * 접근 키의 유효기간 연장 및 즉시 만료를 위한 REST API 엔드포인트가 도입되었습니다.

* **설정 변경**
  * 동시 접속 허용 인원이 5명에서 20명으로 증가했습니다.
  * 접근 키 기본 TTL이 300초에서 120초로 변경되었습니다.
  * 접근 키 최대 TTL(480초) 및 연장 단위(120초) 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->