### PR TITLE
Revert "[AWS 환경 테스트] 운영 환경(prod) 설정 개선 - DB 연결 풀, WebSocket, CORS 설정 추가"

### DIFF
--- a/k6-test/docker-compose.yml
+++ b/k6-test/docker-compose.yml
@@ -51,6 +51,55 @@ services:
     networks:
       - k6-network
 
+  # 좌석 선점 부하테스트 (기존 패턴과 동일하게)
+  k6-seat-test:
+    image: grafana/k6:latest
+    container_name: k6-seat-test
+    restart: "no"
+    profiles: ["seat-test"]
+    volumes:
+      - ./scripts:/scripts:ro  # scripts 폴더 전체를 마운트
+    command: >
+      run --out experimental-prometheus-rw
+      --tag testType=seat-reservation
+      --tag scenario=seat-load-100
+      --summary-trend-stats="min,avg,med,max,p(90),p(95),p(99)"
+      --verbose
+      --no-connection-reuse
+      --batch=50
+      --batch-per-host=20
+      /scripts/SeatLoadTest.js
+    environment:
+      # 🎯 좌석 선점 테스트 설정 (기존 패턴 동일)
+      - TOTAL_USERS=50            # 100명 동시 사용자
+      - CONCURRENT_USERS=50       # 최대 100명
+      - RAMP_UP_DURATION=60s       # 1분에 걸쳐 증가
+      - TEST_DURATION=5m           # 5분간 안정적으로 유지
+      - COOL_DOWN_DURATION=30s     # 1분에 걸쳐 감소
+      - CONCERT_ID=153               # 좌석 선점 테스트용 콘서트 ID
+      - SEAT_COUNT=30             # 좌석 개수
+      - BASE_URL=http://host.docker.internal:8080/api
+      - WS_BASE_URL=ws://host.docker.internal:8080
+      # Prometheus 설정 (기존과 동일)
+      - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
+      - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
+      - K6_PROMETHEUS_RW_PUSH_INTERVAL=10s     # 10초마다 전송
+      - K6_PROMETHEUS_RW_STALE_MARKERS=true    # 안정성 향상
+      - K6_NO_CONNECTION_REUSE=true            # 연결 재사용 비활성화
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: '1.0'
+    depends_on:
+      - prometheus
+    networks:
+      - k6-network
+
   aws-seat-test:
     image: grafana/k6:latest
     container_name: aws-seat-test
@@ -73,8 +122,8 @@ services:
       - CONCURRENT_USERS=100
       - CONCERT_ID=113
       - SEAT_COUNT=60
-      - BASE_URL=http://${AWS_EC2_PUBLIC_IP}:8080/api
-      - WS_BASE_URL=ws://${AWS_EC2_PUBLIC_IP}:8080
+      - BASE_URL=http://host.docker.internal:8080/api
+      - WS_BASE_URL=ws://host.docker.internal:8080
       - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
       - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
       - K6_PROMETHEUS_RW_PUSH_INTERVAL=10s
@@ -95,3 +144,71 @@ services:
       - prometheus
     networks:
       - k6-network
+
+
+
+  k6-loadtest:
+    image: grafana/k6:latest
+    container_name: k6-seat-test
+    restart: "no"
+    profiles: ["seat-test"]
+    volumes:
+      - ./scripts:/scripts:ro
+    command: >
+      run --out experimental-prometheus-rw
+      --tag testType=ticketing
+      --tag scenario=stable-500
+      --summary-trend-stats="min,avg,med,max,p(90),p(95),p(99)"
+      --verbose
+      --no-connection-reuse
+      --batch=10
+      --batch-per-host=5
+      /scripts/ConcurrentLoadTest.js
+    environment:
+      - TOTAL_USERS=500            # 200명 동시 사용자 (성공 확인됨)
+      - CONCURRENT_USERS=100        # 50명씩 4단계로 나누어
+      - RAMP_UP_DURATION=300s      # 4분에 걸쳐 천천히 증가
+      - TEST_DURATION=10m           # 8분간 안정적으로 유지
+      - COOL_DOWN_DURATION=180s    # 2분에 걸쳐 천천히 감소
+      - CONCERT_ID=113
+      - BASE_URL=http://host.docker.internal:8080/api
+      - WS_URL=ws://host.docker.internal:8080/ws/waitqueue
+      - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
+      - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
+      - K6_PROMETHEUS_RW_PUSH_INTERVAL=5s     # 5초마다 전송 (데이터 수집 개선)
+      - K6_PROMETHEUS_RW_STALE_MARKERS=true   # 안정성 향상
+      - K6_WS_COMPRESSION=false               # WebSocket 압축 비활성화
+      - K6_NO_CONNECTION_REUSE=true           # 연결 재사용 비활성화
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: '1.0'
+    depends_on:
+      - prometheus
+    networks:
+      - k6-network
+
+volumes:
+  redis-data:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  k6-network:
+    driver: bridge
+
+# 🚀 좌석 선점 테스트 실행 방법:
+#
+# 1. 인프라 시작:
+#    docker-compose up -d prometheus grafana redis-cache
+#
+# 2. 좌석 선점 부하테스트:
+#    docker-compose --profile seat-test up k6-seat-test
+#
+# 3. 기존 대기열 테스트:
+#    docker-compose --profile load-test up k6-loadtest

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,18 +17,6 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: 100              # 최대 연결 수 (dev: 50 → prod: 100)
-      minimum-idle: 30                    # 최소 유휴 연결 (dev: 20 → prod: 30)
-      connection-timeout: 30000           # 연결 타임아웃 30초 (dev: 20초)
-      idle-timeout: 600000                # 유휴 연결 타임아웃 10분 (dev: 5분)
-      max-lifetime: 1800000               # 연결 최대 수명 30분 (dev: 15분)
-      leak-detection-threshold: 60000     # 연결 누수 감지 1분
-      connection-test-query: SELECT 1     # MySQL 헬스체크 쿼리
-      pool-name: "TicketmonHikariCP"      # 풀 이름 (모니터링용)
-      # 운영 환경 추가 옵션
-      validation-timeout: 5000            # 연결 검증 타임아웃 5초
-      register-mbeans: true               # JMX 모니터링 활성화
 
   # JPA (Hibernate) 관련 설정
   jpa:
@@ -101,37 +89,6 @@ spring:
 app:
   base-url: ${BASE_URL:https://d123456789.cloudfront.net}  # 환경변수 우선, 기본값은 예시 도메인
   front-base-url: ${FRONT_BASE_URL}
-  # 대기열 설정
-  queue:
-    max-active-users: 500            # 운영: 동시 예매 가능 사용자 (dev: 200)
-    top-ranker-count: 200            # 운영: 최상위 대기자 (dev: 100)
-    access-key-ttl-seconds: 600      # 운영: 10분 (dev: 5분)
-    access-key-max-ttl-seconds: 600
-    access-key-extend-seconds: 300   # 운영: 5분 (dev: 3분)
-    scheduler:
-      interval-seconds: 0.3          # 운영: 더 빠른 처리 (dev: 0.5초)
-      batch-size: 150                # 운영: 더 많은 배치 (dev: 100)
-
-  # 🆕 WebSocket 설정 추가 (운영 환경 필수!)
-  websocket:
-    scheduler-health:
-      delay-ms: 30000                # 운영: 30초마다 헬스체크 (dev: 10초)
-    connection:
-      max-idle-time: 600000          # 10분 idle 타임아웃 (dev: 5분)
-      ping-interval: 60000           # 1분마다 ping (dev: 30초)
-      max-connections: 5000          # 최대 5000 연결 (dev: 2000)
-      # 추가 운영 설정
-      buffer-size: 8192              # 버퍼 크기 8KB
-      max-text-message-size: 65536  # 최대 메시지 64KB
-      close-timeout: 30000           # 종료 타임아웃 30초
-
-  # 좌석 예약 설정도 운영에 맞게 조정
-  seat:
-    reservation:
-      ttl-minutes: 10                # 운영: 10분 (dev: 5분)
-      max-seat-count: 4              # 운영: 4석 (dev: 2석)
-    session:
-      max-sessions-per-concert: 5000 # 운영: 5000 (dev: 2000)
 # ☁️ AWS S3 관련 설정
 # 's3' 프로필이 활성화될 때 이 설정이 로드
 # 실제 AWS Access Key, Secret Key는 환경 변수 또는 보안 저장소에서 주입받아야 함
@@ -198,23 +155,8 @@ ai:
 # 🌍 CORS 설정
 cors:
   allowed-origins:
-    # 기존 프로덕션 도메인
-    - "https://ticket-mon.o-r.kr"
-    - "https://api.ticket-mon.o-r.kr"
-
-    # AWS EC2 테스트용 추가
-    - "http://${AWS_EC2_PUBLIC_IP}:8080"
-    - "https://${AWS_EC2_PUBLIC_IP}:8080"
-    - "ws://${AWS_EC2_PUBLIC_IP}:8080"
-    - "wss://${AWS_EC2_PUBLIC_IP}:8080"
-
-    # 로컬에서 AWS로 테스트할 때
-    - "http://localhost:3000"
-    - "http://localhost:8080"
-
-    # K6 Docker 컨테이너에서 접근
-    - "http://host.docker.internal:8080"
-    - "ws://host.docker.internal:8080"
+    - "https://ticket-mon.o-r.kr"          # 프론트엔드 도메인
+    - "https://api.ticket-mon.o-r.kr"      # API 도메인
 
 onesignal:
   app-id: ${ONESIGNAL_APP_ID}        # 운영 환경에서 환경 변수로 관리


### PR DESCRIPTION
Reverts AIBE-3Team/AIBE1_FinalProject_Team03_BE#173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * k6 부하 테스트용 서비스(`k6-seat-test`, `k6-loadtest`)가 추가되고 관련 설정이 업데이트되었습니다.
  * 기존 부하 테스트 서비스의 대상 URL이 로컬 환경으로 변경되었습니다.
  * Redis, Prometheus, Grafana 데이터 볼륨 및 네트워크 정의가 추가되었습니다.
  * Docker Compose 실행 및 테스트 방법에 대한 주석이 추가되었습니다.

* **Refactor**
  * 운영 환경 설정 파일에서 상세한 데이터베이스, 큐, 웹소켓, 좌석 관련 설정이 제거되어 설정이 간소화되었습니다.
  * CORS 허용 도메인이 실제 운영 도메인만 남도록 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->